### PR TITLE
Allow numeric cells to be "empty"

### DIFF
--- a/dist/js/jquery.jexcel.js
+++ b/dist/js/jquery.jexcel.js
@@ -1635,7 +1635,8 @@ var methods = {
                 } else if (options.columns[position[0]].type == 'numeric') {
                     var value = $(cell).find('.editor').val();
                     if (value.substr(0,1) != '=') {
-                        var value = Number(value) || 0;
+                        var default_value = value === '' && options.columns[position[0]].allowEmpty ? '' : 0,
+                            value = Number(value) || default_value;
                     }
                 } else {
                     // Get content


### PR DESCRIPTION
This simple change allows numeric cells to be empty, rather than forcing a value. For example, a "Sale Price" field. If it's empty there's no sale price, but with the current script it'll force to `0` making the item free.

Once merged, simply add `allowEmpty: true` to the `columns` parameter.