### PR TITLE
Avoid blocking paste events when no cell is selected

### DIFF
--- a/dist/js/jquery.jexcel.js
+++ b/dist/js/jquery.jexcel.js
@@ -861,6 +861,9 @@ var methods = {
 
             // IE Compatibility
             $(document).on('paste', function (e) {
+                if ($.fn.jexcel.selectedCell === null) {
+                    return;
+                }
                 if (! $($.fn.jexcel.selectedCell).hasClass('edition')) {
                     if (e.originalEvent) {
                         if ($.fn.jexcel.defaults[$.fn.jexcel.current].editable == true) {


### PR DESCRIPTION
When working with several tables, that can be hidden and shown, they would hijack the paste events along the whole web page.
This tiny patch should be helpful to avoid that