### PR TITLE
Fixes #193 – selectable context menu text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ $('#mytable').jexcel({ data:data, colWidths: [ 300, 80, 100 ] });
 
 ## Examples
 
-
-
-
-
 - [Creating a table from an external CSV file](https://bossanova.uk/jexcel/examples/creating-a-table-from-an-external-csv-file)
 - [Calendar column type](https://bossanova.uk/jexcel/examples/using-a-calendar-column-type)
 - [Sorting by column](https://bossanova.uk/jexcel/examples/reorder)

--- a/dist/css/jquery.jexcel.css
+++ b/dist/css/jquery.jexcel.css
@@ -333,6 +333,9 @@
     color: #555;
     font-family: sans-serif;
     font-size: 11px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
     -webkit-transition: opacity .5s ease-in-out;
     -moz-transition: opacity .5s ease-in-out;
     -ms-transition: opacity .5s ease-in-out;
@@ -354,6 +357,7 @@
     padding: 6px 8px 6px 30px;
     width: 250px;
     position: relative;
+    cursor: default;
 }
 
 .jexcel_contextmenu a span


### PR DESCRIPTION
#### This PR fixes #193

### Summary of changes
The text in the context menu has been marked as `user-select: none` and the cursor for the un`href`d `<a>` tags has been re-adjusted to `cursor: default`.

### Tests
- Chrome 67 – ✅ pass 
- Firefox 61 – ✅ pass 
- Edge – ✅ pass 