### PR TITLE
fix: hide formula error, insert '=$' in cell

### DIFF
--- a/dist/js/jquery.jexcel.js
+++ b/dist/js/jquery.jexcel.js
@@ -2147,6 +2147,9 @@ var methods = {
         // Cell identification
         var position = [v.col, v.row];
 
+        // Remove formula error
+        $(v.cell).removeClass('error');
+
         // Value
         value = '' + v.newValue;
 
@@ -3925,6 +3928,11 @@ var methods = {
      * Run the formula for one given cell
      */
     executeFormula : function (cellId) {
+
+        // Not calculate and not show error if excelFormulaUtilities is not defined
+        if (typeof excelFormulaUtilities !== 'object')
+            return;
+
         // Id
         var id = $(this).prop('id');
 
@@ -3945,7 +3953,7 @@ var methods = {
         }
 
         // Set value
-        if (value === null || value == undefined || (''+value) == 'NaN') {
+        if (value === null || value == undefined || (''+value) == 'NaN' || typeof value === 'function') {
             // New cell value
             value = '<input type="hidden" value="' + formula + '">#ERROR';
             // Add class error to the cell


### PR DESCRIPTION
1) 2150-2152 fixed  show "error", if after formula error write simple value
2) 3931-3952 not calculate and not show error if excelFormulaUtilities is not defined
3) 3956 fixed insert '=$', show error instead function

1.
 ![Screenshot from 2019-05-11 17-01-52](https://user-images.githubusercontent.com/16453229/57571207-abfa0280-7413-11e9-8ef6-f6bd52351d8d.png)
![Screenshot from 2019-05-11 17-02-15](https://user-images.githubusercontent.com/16453229/57571211-b7e5c480-7413-11e9-9577-08a1980871f2.png)
![Screenshot from 2019-05-11 17-02-20](https://user-images.githubusercontent.com/16453229/57571212-ba481e80-7413-11e9-9c83-c97fe6c91eee.png)

3. 
![Screenshot from 2019-05-11 17-12-49](https://user-images.githubusercontent.com/16453229/57571221-ce8c1b80-7413-11e9-9aee-a80c03f44813.png)
![Screenshot from 2019-05-11 17-12-53](https://user-images.githubusercontent.com/16453229/57571222-d350cf80-7413-11e9-8657-7e241775b482.png)


