### PR TITLE
v2: cssClass for individual nestedHeader, supply ids to jexcel_labels

### DIFF
--- a/dist/js/jquery.jexcel.js
+++ b/dist/js/jquery.jexcel.js
@@ -398,7 +398,7 @@ var methods = {
                     }
 
                     // Classes container
-                    var headerClasses = '';
+                    var headerClasses = nestedInformation[i].cssClass || '';
                     // Header classes for this cell
                     for (var x = 0; x < nestedInformation[i].colspan; x++) {
                         if (headerClasses) {
@@ -1523,7 +1523,7 @@ var methods = {
             $(tr).prop('id', 'row-' + parseInt(j));
 
             // Index column
-            $(tr).append('<td class="jexcel_label">' + parseInt(j + 1) + '</td>'); 
+            $(tr).append('<td class="jexcel_label" id="jexcel_label_' + j + '">' + parseInt(j + 1) + '</td>');
 
             // Data columns
             for (i = 0; i < $.fn.jexcel.defaults[id].colHeaders.length; i++) {
@@ -3254,7 +3254,7 @@ var methods = {
                 var tr = document.createElement('tr');
 
                 // Index column
-                $(tr).append('<td class="jexcel_label"></td>');
+                $(tr).append('<td class="jexcel_label" id="jexcel_label_' + row + '"></td>');
 
                 // New row
                 $.fn.jexcel.defaults[id].data[row] = [];


### PR DESCRIPTION
I'm not sure if v2 is still open for pull requests since v3 is about to be released, but since v2 is in a separate branch, I think it's still valuable to make minor fixes. Also it seems that v3 is drastically different from v2, and likely not very stable yet, v2 should still remain functional until v3 is ready.

This pull request contains cssClass for individual nestedHeader, which could be useful if anyone wants to style each nestedHeader differently. the ids for jexcel_labels is just a workaround for the mousedown condition, as suggested by @TheNeverK