### PR TITLE
v2: .jexcel_external to avoid styling conflicts for custom editors

### DIFF
--- a/dist/js/jquery.jexcel.js
+++ b/dist/js/jquery.jexcel.js
@@ -809,7 +809,7 @@ var methods = {
                             }
                         } else {
                             // Check if the object is in the jexcel domain
-                            if (! $(e.target).parents('.jexcel, .jexcel_contextmenu').length) {
+                            if (! $(e.target).parents('.jexcel, .jexcel_contextmenu, .jexcel_external').length) {
                                 // Keep selection if main scrollbar is selected
                                 if (e.target != $('html').get(0)) {
                                     $('#' + $.fn.jexcel.current).jexcel('resetSelection');


### PR DESCRIPTION
I've been working with 2.1.0 recently and this seems to be an issue still. Sure I can add .jexcel to external modal, but as long as I use the default jexcel stylesheet, there will be tons of styles that are designed for jexcel but not really for the external modal, which results in a broken page. I can confirm that adding .jexcel to Bootstrap modals would not work. It should really just be a separate class that is not referred anywhere in the jexcel code besides that one line determining if the modal is within the domain.