### PR TITLE
Preserve pre-configured column titles

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5310,7 +5310,9 @@ var jexcel = (function(el, options) {
                                 if (! obj.options.columns[i]) {
                                     obj.options.columns[i] = { type:'text', align:'center', width:obj.options.defaultColWidth };
                                 }
-                                obj.options.columns[i].title = headers[i];
+                                if (typeof obj.options.columns[i].title === 'undefined'){
+                                  obj.options.columns[i].title = headers[i];
+                                }
                             }
                         }
 


### PR DESCRIPTION
I'm pulling a CSV from a REST interface that includes a list of field names as headers. I've built a column configuration array with human-friendly titles but those titles get overwritten by the CSV load. This PR allows developers who have pre-configured a title to keep it while still keeping the default configurations provided when csvHeaders is true.