### PR TITLE
Fix errors from empty source csv

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5335,7 +5335,7 @@ var jexcel = (function(el, options) {
                         var data = obj.parseCSV(data, obj.options.csvDelimiter)
 
                         // Headers
-                        if (obj.options.csvHeaders == true) {
+                        if (obj.options.csvHeaders == true && data.length > 0) {
                             var headers = data.shift();
                             for(var i = 0; i < headers.length; i++) {
                                 if (! obj.options.columns[i]) {

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -233,7 +233,8 @@ var jexcel = (function(el, options) {
         // Number of columns
         var size = obj.options.columns.length;
 
-        if (obj.options.data[0].length > size) {
+        if (typeof obj.options.data[0] !== 'undefined' &&
+            obj.options.data[0].length > size) {
             size = obj.options.data[0].length;
         }
 


### PR DESCRIPTION
I have a dynamic source CSV that sometimes returns an empty CSV causing the console to log errors due to undefined values. Since I configure the columns separately and want a spare row, I should still be able to render the spreadsheet.

This PR adds checks to ensure that the spreadsheet still renders even if I provide an empty CSV. 