### PR TITLE
Fixed and improved cell meta to respect adding and deleting

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -2747,7 +2747,7 @@ var jexcel = (function(el, options) {
      * Get table config information
      */
     obj.getConfig = function() {
-        var options = obj.options;
+        var options = Object.assign({}, obj.options);
         options.style = obj.getStyle();
         options.mergeCells = obj.getMerge();
 

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -2890,6 +2890,90 @@ var jexcel = (function(el, options) {
     }
 
     /**
+     * Shifts columns meta information
+     *
+     * @param columnIndex - the index of a reference column
+     * @param pivot - desired shift value
+     * @return {Object.<string, Object>} new meta information
+     */
+    obj.shiftColumnMeta = function (columnIndex, pivot = 1) {
+        let newMeta = {};
+        Object.entries(obj.options.meta).forEach(([cellName, metaData]) => {
+            const [x, y] = jexcel.getIdFromColumnName(cellName, true);
+            if (columnIndex <= x) {
+                newMeta[jexcel.getColumnNameFromId([x + pivot, y])] = metaData;
+            } else {
+                newMeta[cellName] = metaData;
+            }
+        });
+
+        return obj.options.meta = newMeta;
+    };
+
+    /**
+     * Shifts rows meta information
+     *
+     * @param rowIndex - the index of a reference row
+     * @param pivot - desired shift value
+     * @return {Object.<string, Object>} new meta information
+     */
+    obj.shiftRowMeta = function (rowIndex, pivot = 1) {
+        let newMeta = {};
+        Object.entries(obj.options.meta).forEach(([cellName, metaData]) => {
+            const [x, y] = jexcel.getIdFromColumnName(cellName, true);
+            if (rowIndex <= y) {
+                newMeta[jexcel.getColumnNameFromId([x, y + pivot])] = metaData;
+            } else {
+                newMeta[cellName] = metaData;
+            }
+        });
+
+        return obj.options.meta = newMeta;
+    };
+
+    /**
+     * Deletes columns meta information
+     *
+     * @param columnIndex - the index of a reference column
+     * @param numberOfColumns - how many columns are deleted
+     * @return {Object.<string, Object>} new meta information
+     */
+    obj.deleteColumnMeta = function (columnIndex, numberOfColumns = 1) {
+        let newMeta = {};
+        Object.entries(obj.options.meta).forEach(([cellName, metaData]) => {
+            const [x, y] = jexcel.getIdFromColumnName(cellName, true);
+            if (columnIndex <= x && x < columnIndex + numberOfColumns) {
+                // delete
+            } else {
+                newMeta[cellName] = metaData;
+            }
+        });
+
+        return obj.options.meta = newMeta;
+    };
+
+    /**
+     * Deletes rows meta information
+     *
+     * @param rowIndex - the index of a reference column
+     * @param numberOfRows - how many rows are deleted
+     * @return {Object.<string, Object>} new meta information
+     */
+    obj.deleteRowMeta = function (rowIndex, numberOfRows = 1) {
+        let newMeta = {};
+        Object.entries(obj.options.meta).forEach(([cellName, metaData]) => {
+            const [x, y] = jexcel.getIdFromColumnName(cellName, true);
+            if (rowIndex <= y && y < rowIndex + numberOfRows) {
+                // delete
+            } else {
+                newMeta[cellName] = metaData;
+            }
+        });
+
+        return obj.options.meta = newMeta;
+    };
+
+    /**
      * Move row
      * 
      * @return void
@@ -3080,7 +3164,10 @@ var jexcel = (function(el, options) {
                 rowNode: rowNode,
             });
 
-            // Remove table references
+            // Update meta
+            obj.shiftRowMeta(rowIndex, 1);
+
+            // Update table references
             obj.updateTableReferences();
 
             // Events
@@ -3203,7 +3290,11 @@ var jexcel = (function(el, options) {
                         rowNode: rowNode
                     });
 
-                    // Remove table references
+                    // Delete meta
+                    obj.deleteRowMeta(rowNumber, numOfRows);
+                    obj.shiftRowMeta(rowNumber, -1 * numOfRows);
+
+                    // Delete table references
                     obj.updateTableReferences();
 
                     // Events
@@ -3218,7 +3309,6 @@ var jexcel = (function(el, options) {
             }
         }
     }
-
 
     /**
      * Move column
@@ -3281,7 +3371,6 @@ var jexcel = (function(el, options) {
             }
         }
     }
-
 
     /**
      * Insert a new column
@@ -3444,7 +3533,10 @@ var jexcel = (function(el, options) {
                 data:historyData,
             });
 
-            // Remove table references
+            // Update meta
+            obj.shiftColumnMeta(columnIndex, 1);
+
+            // Update table references
             obj.updateTableReferences();
 
             // Events
@@ -3589,7 +3681,11 @@ var jexcel = (function(el, options) {
                         data:historyData,
                     });
 
-                    // Update table references
+                    // Delete meta
+                    obj.deleteColumnMeta(columnNumber, numOfColumns);
+                    obj.shiftColumnMeta(columnNumber, -1 * numOfColumns);
+
+                    // Delete table references
                     obj.updateTableReferences();
 
                     // Delete

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -3091,7 +3091,7 @@ var jexcel = (function(el, options) {
             // Onbeforeinsertrow
             if (typeof(obj.options.onbeforeinsertrow) == 'function') {
                 if (! obj.options.onbeforeinsertrow(el, rowNumber, numOfRows, insertBefore)) {
-                    console.log('onbeforeinsertrow returned false');
+                    console.log('JEXCEL: onbeforeinsertrow returned false');
 
                     return false;
                 }
@@ -3231,7 +3231,7 @@ var jexcel = (function(el, options) {
                 // Onbeforedeleterow
                 if (typeof(obj.options.onbeforedeleterow) == 'function') {
                     if (! obj.options.onbeforedeleterow(el, rowNumber, numOfRows)) {
-                        console.log('onbeforedeleterow returned false');
+                        console.log('JEXCEL: onbeforedeleterow returned false');
                         return false;
                     }
                 }
@@ -3424,7 +3424,7 @@ var jexcel = (function(el, options) {
             // Onbeforeinsertcolumn
             if (typeof(obj.options.onbeforeinsertcolumn) == 'function') {
                 if (! obj.options.onbeforeinsertcolumn(el, columnNumber, numOfColumns, insertBefore)) {
-                    console.log('onbeforeinsertcolumn returned false');
+                    console.log('JEXCEL: onbeforeinsertcolumn returned false');
 
                     return false;
                 }
@@ -3605,7 +3605,7 @@ var jexcel = (function(el, options) {
                 // onbeforedeletecolumn
                 if (typeof(obj.options.onbeforedeletecolumn) == 'function') {
                    if (! obj.options.onbeforedeletecolumn(el, columnNumber, numOfColumns)) {
-                      console.log('onbeforedeletecolumn returned false');
+                      console.log('JEXCEL: onbeforedeletecolumn returned false');
                       return false;
                    }
                 }
@@ -4061,7 +4061,7 @@ var jexcel = (function(el, options) {
         // Code protection
         obj.formulaStack++;
         if (obj.formulaStack > 5) {
-            console.error('Too many executions...');
+            console.error('JEXCEL: Too many executions...');
             return 0;
         }
         // Parent column identification
@@ -4954,7 +4954,7 @@ var jexcel = (function(el, options) {
      */
     obj.download = function(includeHeaders) {
         if (obj.options.allowExport == false) {
-            console.error('Export not allowed');
+            console.error('JEXCEL: Export not allowed');
         } else {
             // Data
             var data = '';
@@ -5487,7 +5487,7 @@ var jexcel = (function(el, options) {
                 }
             }
         } else {
-            console.error('Invalid column');
+            console.error('JEXCEL: Invalid column');
         }
 
         return (value.length > 0) ? value.join('; ') : '';

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -127,6 +127,7 @@ var jexcel = (function(el, options) {
         onselection:null,
         onpaste:null,
         onmerge:null,
+        onremovemerge:null,
         onfocus:null,
         onblur:null,
         // Customize any cell behavior
@@ -1087,6 +1088,9 @@ var jexcel = (function(el, options) {
             // In the initialization is not necessary keep the history
             obj.updateSelection(obj.records[cell[1]][cell[0]]);
 
+            // Update table references
+            obj.updateTableReferences();
+
             if (! ignoreHistoryAndEvents) {
                 obj.setHistory({
                     action:'setMerge',
@@ -1135,7 +1139,7 @@ var jexcel = (function(el, options) {
      * Remove merge by cellname
      * @param cellName
      */
-    obj.removeMerge = function(cellName, data, keepOptions) {
+    obj.removeMerge = function(cellName, data, keepOptions, ignoreHistoryAndEvents) {
         if (obj.options.mergeCells[cellName]) {
             var cell = jexcel.getIdFromColumnName(cellName, true);
             obj.records[cell[1]][cell[0]].removeAttribute('colspan');
@@ -1161,8 +1165,25 @@ var jexcel = (function(el, options) {
             // Update selection
             obj.updateSelection(obj.records[cell[1]][cell[0]], obj.records[cell[1]+j-1][cell[0]+i-1]);
 
+            // Update table references
+            obj.updateTableReferences();
+
             if (! keepOptions) {
                 delete(obj.options.mergeCells[cellName]);
+            }
+
+            if (! ignoreHistoryAndEvents) {
+                obj.setHistory({
+                    action: 'removeMerge',
+                    column: cellName,
+                    colspan: info[0],
+                    rowspan: info[1],
+                    // data: data,
+                });
+
+                if (typeof(obj.options.onremovemerge) == 'function') {
+                    obj.options.onremovemerge(el, cellName, info[0], info[1]/*, data*/);
+                }
             }
         }
     }

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -2507,7 +2507,7 @@ var jexcel = (function(el, options) {
 
     /**
      * Set meta information to cell(s)
-     * 
+     *
      * @return integer
      */
     obj.setMeta = function(o, k, v) {
@@ -2516,11 +2516,17 @@ var jexcel = (function(el, options) {
         }
 
         if (k && v) {
-            // Set data value
+            // Set cell meta value by key
             if (! obj.options.meta[o]) {
                 obj.options.meta[o] = {};
             }
             obj.options.meta[o][k] = v;
+        } else if (k) {
+            // Set cell meta value
+            if (! obj.options.meta[o]) {
+                obj.options.meta[o] = {};
+            }
+            obj.options.meta[o] = k;
         } else {
             // Apply that for all cells
             var keys = Object.keys(o);
@@ -2535,6 +2541,9 @@ var jexcel = (function(el, options) {
                 }
             }
         }
+
+        // Update table references
+        obj.updateTableReferences();
     }
 
     /**

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -270,7 +270,7 @@ var jexcel = (function(el, options) {
             // Default column description
             if (! obj.options.columns[i]) {
                 obj.options.columns[i] = { type:'text' };
-            } else if (! obj.options.columns[i]) {
+            } else if (! obj.options.columns[i].type) {
                 obj.options.columns[i].type = 'text';
             }
             if (! obj.options.columns[i].source) {


### PR DESCRIPTION
There are a few main changes here:
1. Improved `setMeta()` to support setting meta information for entire cell
2. Improved `setMeta()` to call `updateTableReferences()` - in case something in a table relies on meta information (we use `updateTable()` option to tune cells based on their meta)
3. **Adding/removing columns and rows now adjust meta information accordingly(!)**
4. All console output commands start with "JEXCEL: " - to be clear and consistent

What is missing in this pull request:
1. Support for meta in `undo()` & `redo()`

What is missing in general:
2. Cell merging is supported by `undo()` but not by `redo()`

I have tried to fix `undo()` & `redo()` but it seems to require more time than I can spend ATM.
Moreover, these methods use opposite function for every type of event to revert changes which seems to be more optimal but also complicate things significantly and introduce plenty of bugs.
Is performance a reason to not use entire snapshots of the table which would pretty much solve them all?

