### PR TITLE
Bugfix: calling getConfig() removed mergeCells NODEs

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -2738,7 +2738,7 @@ var jexcel = (function(el, options) {
      * Get table config information
      */
     obj.getConfig = function() {
-        var options = obj.options;
+        var options = Object.assign({}, obj.options);
         options.style = obj.getStyle();
         options.mergeCells = obj.getMerge();
 


### PR DESCRIPTION
Change in 7fbee25e37ccde9c8a848d438d99a3510dc1c597 broke `setMerge()` and `removeMerge()`
You really shouldn't store NODEs in table options, it creates so many issues...
