### PR TITLE
Fixed download function with header active

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -4859,7 +4859,7 @@ var jexcel = (function(el, options) {
             // Data
             var data = '';
             if (includeHeaders == true) {
-                data += obj.getHeaders();
+                data += obj.getHeaders().concat('\n');
             }
             // Get data
             data += obj.copy(false, ',', true);


### PR DESCRIPTION
The problem was because when the header is active, in the **header line** not has added the **end line character**, causing the next line of data appears next to the header instead of in a new line.