### PR TITLE
 Fixed context menu deleting when no column or row is selected

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5569,7 +5569,7 @@ var jexcel = (function(el, options) {
                     items.push({
                         title:obj.options.text.deleteSelectedColumns,
                         onclick:function() {
-                            obj.deleteColumn();
+                            obj.deleteColumn(obj.getSelectedColumns().length ? undefined : parseInt(x));
                         }
                     });
                 }

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5624,7 +5624,7 @@ var jexcel = (function(el, options) {
                     items.push({
                         title:obj.options.text.deleteSelectedRows,
                         onclick:function() {
-                            obj.deleteRow();
+                            obj.deleteRow(obj.getSelectedRows().length ? undefined : parseInt(y));
                         }
                     });
                 }


### PR DESCRIPTION
Fixed context menu removing last row/column instead of the one under cursor, when no rows/columns are selected