### PR TITLE
CSV download has label values if copyCompatibility is true

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5011,6 +5011,11 @@ var jexcel = (function(el, options) {
             }
         }*/
 
+        // Return strLabel if copy compatible
+        if (obj.options.copyCompatibility == true) {
+            return strLabel;
+        }
+
         return str;
     }
 


### PR DESCRIPTION
If copyCompatibility is set to true, the downloaded csv will now contain the label values instead of the id values. This functionality was suggested in issue #346 