### PR TITLE
#565 - Allow other delimiters for CSV export

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -2690,7 +2690,7 @@ var jexcel = (function(el, options) {
             title.push(obj.getHeader(i));
         }
 
-        return asArray ? title : title.join(',');
+        return asArray ? title : title.join(obj.options.csvDelimiter);
     }
 
     /**
@@ -5107,7 +5107,7 @@ var jexcel = (function(el, options) {
                 data += "\r\n";
             }
             // Get data
-            data += obj.copy(false, ',', true);
+            data += obj.copy(false, obj.options.csvDelimiter, true);
             // Download element
             var pom = document.createElement('a');
             var blob = new Blob([data], {type: 'text/csv;charset=utf-8;'});


### PR DESCRIPTION
This is a commit to fix the issue I've just raised https://github.com/paulhodel/jexcel/issues/565 - it allows a user to define a different CSV delimiter for export - reusing the option we already have for import, useful for internationalisation.

Thanks,
Brett