### PR TITLE
Allow deleting of all rows

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -71,6 +71,8 @@ var jexcel = (function(el, options) {
         allowManualInsertColumn:true,
         // Allow row delete
         allowDeleteRow:true,
+		// Allow deleting of all rows
+		allowDeletingAllRows:false,
         // Allow column delete
         allowDeleteColumn:true,
         // Allow rename column
@@ -3285,7 +3287,7 @@ var jexcel = (function(el, options) {
     obj.deleteRow = function(rowNumber, numOfRows) {
         // Global Configuration
         if (obj.options.allowDeleteRow == true) {
-            if (obj.options.data.length > 1) {
+            if (obj.options.allowDeletingAllRows || obj.options.data.length > 1) {
                 // Delete row definitions
                 if (rowNumber == undefined) {
                     var number = obj.getSelectedRows();


### PR DESCRIPTION
Hi,

I have a need to allow deleting of all rows, which isn't allowed currently - I understand why - but in my use case that is fine. I've added a new property (false by default) allowing the deletion of all rows if it's been manually set to true.