### PR TITLE
Add imageOptions so we can pass these to jSuite

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -79,6 +79,8 @@ var jexcel = (function(el, options) {
         allowComments:false,
         // Global wrap
         wordWrap:false,
+        // Image options
+        imageOptions: null,
         // CSV source
         csv:null,
         // Filename
@@ -1398,7 +1400,7 @@ var jexcel = (function(el, options) {
                         div.appendChild(img);
                     }
                     editor.appendChild(div);
-                    jSuites.image(div);
+                    jSuites.image(div, obj.options.imageOptions);
                     const rect = cell.getBoundingClientRect();
                     const rectContent = div.getBoundingClientRect();
                     if (window.innerHeight < rect.bottom + rectContent.height) {


### PR DESCRIPTION
This combined with the PR in jSuites allows us to add image compression

Add three options:

maxWidth: null,
maxHeight: null,
maxJpegSizeBytes: null

The intention is to preserve the aspect ratio while limiting the image size