### PR TITLE
Generalise AJAX calls to allow for POST requests

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -81,6 +81,9 @@ var jexcel = (function(el, options) {
         wordWrap:false,
         // Image options
         imageOptions: null,
+        // Ajax options
+        ajaxMethod: 'GET',
+        postData: null,
         // CSV source
         csv:null,
         // Filename
@@ -5666,7 +5669,8 @@ var jexcel = (function(el, options) {
             // Load CSV file
             jSuites.ajax({
                 url: obj.options.csv,
-                method: 'GET',
+                method: obj.options.ajaxMethod,
+                data: obj.options.postData,
                 dataType: 'text',
                 success: function(result) {
                     // Convert data
@@ -5703,7 +5707,8 @@ var jexcel = (function(el, options) {
 
             jSuites.ajax({
                 url: obj.options.url,
-                method: 'GET',
+                method: obj.options.ajaxMethod,
+                data: obj.options.postData,
                 dataType: 'json',
                 success: function(result) {
                     // Data


### PR DESCRIPTION
Add settings that allow for setting a post request and post data. The underlying jsuite.ajax() already has support for this.

I am working with large datasets and server side filtering with fairly complex filters that are a bit nicer to handle with POST requests.

I haven't touched the autocomplete ajax call, as it seems to make less sense there, however similar could be done through the column settings.

