### PR TITLE
Correct variable name passed to onbeforepaste callback

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5353,7 +5353,7 @@ var jexcel = (function(el, options) {
     obj.paste = function(x, y, data) {
         // Paste filter
         if (typeof(obj.options.onbeforepaste) == 'function') {
-            var data = obj.options.onbeforepaste(instance, data);
+            var data = obj.options.onbeforepaste(el, data);
         }
 
         // Controls


### PR DESCRIPTION
The onbeforepaste callback is failing due to the undefined variable. This pull request fixes the variable name and makes the onbeforepaste event usable.