### PR TITLE
Execute formulas after they have been updated by something like a row insert

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -4227,6 +4227,17 @@ var jexcel = (function(el, options) {
             }
         }
         obj.formula = formula;
+
+		for (var j = 0; j < obj.options.data.length; j++) {
+			for (var i = 0; i < obj.options.data[0].length; i++) {
+				var value = '' + obj.options.data[j][i];
+				// Is formula
+				if (value.substr(0, 1) == '=') {
+					obj.executeFormula(value, i, j);
+				}
+			}
+		}
+
     }
 
     /**


### PR DESCRIPTION
When a new row is inserted (and I'm sure other certain actions) the formulas pertaining to that group of rows are correctly updated. However when adding data to this new row, the fields with formulas that were just updated to include this new row don't pick up the data for calculation. If you click on one of these formula fields to force resaving it, then it calculates correctly. This fix forces the formulas to fully update and 'become aware' of the new row/data.