### PR TITLE
Remove scroll event listeners on jexcel destroy

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -6146,6 +6146,8 @@ jexcel.timeControlLoading= null;
 
 jexcel.destroy = function(element, destroyEventHandlers) {
     if (element.jexcel) {
+        element.removeEventListener("DOMMouseScroll", element.jexcel.scrollControls);
+        element.removeEventListener("mousewheel", element.jexcel.scrollControls);
         element.jexcel = null;
         element.innerHTML = '';
 


### PR DESCRIPTION
Currently when you destroy jexcel and create it again, lazy load won't work and on scroll it will try to operate on previously destroyed elements (eg obj.tbody). Removing scroll listeners on jexcel destroy resolves this issue.