### PR TITLE
Fix copyCompatibility bug in copy method for checkbox column data

### DIFF
--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -5340,12 +5340,45 @@ var jexcel = (function(el, options) {
                     col.push(value);
 
                     // Labels
-                    var label = obj.records[j][i].innerHTML;
-                    if (label.match && (label.match(/,/g) || label.match(/\n/) || label.match(/\"/))) {
-                        // Scape double quotes
-                        label = label.replace(new RegExp('"', 'g'), '""');
-                        label = '"' + label + '"';
+                    /* This section will deal with how to treat various types of column data so that when
+                     * we paste it into some excel-like spreadsheet software, the data will actually show
+                     * up as we intend.
+                     * Currently, this is the specification:
+                     *    COLUMN TYPE     JEXCEL DATA EXAMPLE                   CLIPBOARD DATA EXAMPLE
+                     *    checkbox        <input type="checkbox" name="c2">     true (or false)
+                    */ 
+
+                    var setLabel = function(obj, i, j) {
+
+                        var label = "";
+
+                        // CHECKBOX
+                        if(obj.options.columns[i].type == "checkbox" && obj.records[j][i].innerHTML.includes('<input type="checkbox"')) {
+
+                            return value;
+
+                        }
+                        
+                        // Handle value to copy if the cell in the column was overriden with something, or if it isn't
+                        // one of the above cases -- this can be in the case when the value is overriden with some text
+                        // like if the user puts the string "TOTAL" in the checkbox column in the last row
+                    
+                        label = obj.records[j][i].innerHTML;
+
+                        if (label.match && (label.match(/,/g) || label.match(/\n/) || label.match(/\"/))) {
+
+                            // Escape double quotes
+                            label = label.replace(new RegExp('"', 'g'), '""');
+                            label = '"' + label + '"';
+
+                        }
+
+                        return label;
+
                     }
+
+                    var label = setLabel(obj, i, j);
+
                     colLabel.push(label);
 
                     // Get style


### PR DESCRIPTION
When the option copyCompatibility: true, there is currently a bug where it copies the innerHTML rather than value of TRUE/FALSE.

The fix is to check the column type, and modify the treatment of the text that is copied into the clipboard.

In the case of checkbox, we should NOT do the previous default behavior of copying the innerHTML, instead, we should copy the value of TRUE or FALSE. However, if the default innerHTML has been overriden programmatically by the user, then we should revert to default treatment of copying the innerHTML, as the value can no longer be relied on being the intended copy source.

This patch maintains backwards compatibility, while adding a new fork in the control flow to better handle different column data-types, such as: image, color bar, etc. The intent is to improve ease of copy/pasting data into ASCII that can be understood by most spreadsheet apps when the data is pasted into them. At the moment, this patch is only proposing a solution to handling the checkbox. Future patches can be easily coded to handle other cases noted above.