### PR TITLE
added minimal support for direction RTL - you can adjust column width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ![The JavaScript spreadsheet](https://bossanova.uk/templates/default/img/logo-jexcel.png)
 
+# Hebrew support, not complete
+
+To enable rtl column width change, you need to add the special class: dirRtl to both the body and the div of the jExcel.
+Some behavior is improved, not all.
+
+
 [**jExcel CE**](https://bossanova.uk/jexcel/v3/) is a lightweight Vanilla JavaScript plugin to create amazing web-based interactive HTML tables and spreadsheets compatible
 with Excel or any other spreadsheet software. You can create an online spreadsheet table from a JS array,
 JSON, CSV or XSLX files. You can copy from excel and paste straight to your jExcel CE spreadsheet and vice versa.

--- a/src/css/jexcel.css
+++ b/src/css/jexcel.css
@@ -7,6 +7,10 @@
  * 
  * This software is distribute under MIT License
  */
+
+.dirRtl {
+    direction: rtl;
+}
 :root {
     --jexcel-border-color:#000;
 }
@@ -92,7 +96,7 @@
     cursor:move;
 }
 
-.jexcel > thead.resizable > tr > td::after
+body:not(.dirRtl) .jexcel > thead.resizable > tr > td::after
 {
     content:'\00a0';
     width:3px;
@@ -100,6 +104,17 @@
     position:absolute;
     top:0px;
     right:0px;
+    cursor:col-resize;
+}
+
+body.dirRtl .jexcel > thead.resizable > tr > td::before
+{
+    content:'\00a0';
+    width:3px;
+    height:100%;
+    position:absolute;
+    top:0px;
+    left:0px;
     cursor:col-resize;
 }
 

--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -6440,6 +6440,10 @@ jexcel.keyDownControls = function(e) {
 
 jexcel.isMouseAction = false;
 
+jexcel.isRtl = function(){
+    return document.body.classList.contains('dirRtl');
+}
+
 jexcel.mouseDownControls = function(e) {
     e = e || window.event;
     if (e.buttons) {
@@ -6483,7 +6487,7 @@ jexcel.mouseDownControls = function(e) {
                 if (columnId) {
                     // Update cursor
                     var info = e.target.getBoundingClientRect();
-                    if (jexcel.current.options.columnResize == true && info.width - e.offsetX < 6) {
+                    if (jexcel.current.options.columnResize == true && (!jexcel.isRtl() && info.width - e.offsetX < 6 || jexcel.isRtl() && e.offsetX < 6)) {
                         // Resize helper
                         jexcel.current.resizing = {
                             mousePosition: e.pageX,
@@ -6779,8 +6783,8 @@ jexcel.mouseMoveControls = function(e) {
                 if (jexcel.current.resizing.column) {
                     var width = e.pageX - jexcel.current.resizing.mousePosition;
 
-                    if (jexcel.current.resizing.width + width > 0) {
-                        var tempWidth = jexcel.current.resizing.width + width;
+                    if (jexcel.current.resizing.width + width * (jexcel.isRtl()? -1 : 1) > 0) {
+                        var tempWidth = jexcel.current.resizing.width + width * (jexcel.isRtl()? -1 : 1);
                         jexcel.current.colgroup[jexcel.current.resizing.column].setAttribute('width', tempWidth);
 
                         jexcel.current.updateCornerPosition();
@@ -6808,7 +6812,7 @@ jexcel.mouseMoveControls = function(e) {
 
             if (e.target.parentNode.parentNode && e.target.parentNode.parentNode.className) {
                 if (e.target.parentNode.parentNode.classList.contains('resizable')) {
-                    if (e.target && x && ! y && (rect.width - (e.clientX - rect.left) < 6)) {
+                    if (e.target && x && ! y && (!jexcel.isRtl() && (rect.width - (e.clientX - rect.left) < 6) || jexcel.isRtl() && (e.clientX - rect.left < 6))) {
                         jexcel.current.cursor = e.target;
                         jexcel.current.cursor.style.cursor = 'col-resize';
                     } else if (e.target && ! x && y && (rect.height - (e.clientY - rect.top) < 6)) {


### PR DESCRIPTION
Added an ugly message to the readme, sorry.
Tried to be as minimal as possible, added function

    jexcel.isRtl()

Limitation I had is that you need to ask the user to add the class "dirRtl" to both the body and the div of the jexcel. Reason is the css that changes the cursor to col-width.

Also - I didn't build the project - just changed the source files.