### PR TITLE
Fix style on cell readonly

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -3036,7 +3036,7 @@ var jexcel = (function(el, options) {
             // Position
             var cell = jexcel.getIdFromColumnName(cellId, true);
 
-            if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]]) {
+            if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]] && (obj.records[cell[1]][cell[0]].classList.contains('readonly')==false || force)) {
                 // Current value
                 var currentValue = obj.records[cell[1]][cell[0]].style[key];
 

--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -3012,7 +3012,7 @@ var jexcel = (function(el, options) {
             // Position
             var cell = jexcel.getIdFromColumnName(cellId, true);
 
-            if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]]) {
+            if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]] && (obj.records[cell[1]][cell[0]].classList.contains('readonly')==false || force)) {
                 // Current value
                 var currentValue = obj.records[cell[1]][cell[0]].style[key];
 


### PR DESCRIPTION
Hi Paul,

You find a patch for setStyle with a cell in readonly

on setStyle => Apply function, change

`if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]]) {`

on

`if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]] && (obj.records[cell[1]][cell[0]].classList.contains('readonly')==false || force)) {`

if force is set to True, setStyle apply is executed.