### PR TITLE
Undo redo ignore event option

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -3036,7 +3036,7 @@ var jexcel = (function(el, options) {
             // Position
             var cell = jexcel.getIdFromColumnName(cellId, true);
 
-            if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]]) {
+            if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]] && (obj.records[cell[1]][cell[0]].classList.contains('readonly')==false || force)) {
                 // Current value
                 var currentValue = obj.records[cell[1]][cell[0]].style[key];
 

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5808,12 +5808,12 @@ var jexcel = (function(el, options) {
     /**
      * Undo last action
      */
-    obj.undo = function() {
+    obj.undo = function(OptionIgnoreEvent) {
         // Ignore events and history
         var ignoreEvents = obj.ignoreEvents ? true : false;
         var ignoreHistory = obj.ignoreHistory ? true : false;
 
-        obj.ignoreEvents = true;
+        obj.ignoreEvents = OptionIgnoreEvent == null ? true : OptionIgnoreEvent;
         obj.ignoreHistory = true;
 
         // Records
@@ -5884,12 +5884,12 @@ var jexcel = (function(el, options) {
     /**
      * Redo previously undone action
      */
-    obj.redo = function() {
+    obj.redo = function(OptionIgnoreEvent) {
         // Ignore events and history
         var ignoreEvents = obj.ignoreEvents ? true : false;
         var ignoreHistory = obj.ignoreHistory ? true : false;
 
-        obj.ignoreEvents = true;
+        obj.ignoreEvents = OptionIgnoreEvent == null ? true : OptionIgnoreEvent;
         obj.ignoreHistory = true;
 
         // Records

--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -3012,7 +3012,7 @@ var jexcel = (function(el, options) {
             // Position
             var cell = jexcel.getIdFromColumnName(cellId, true);
 
-            if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]]) {
+            if (obj.records[cell[1]] && obj.records[cell[1]][cell[0]] && (obj.records[cell[1]][cell[0]].classList.contains('readonly')==false || force)) {
                 // Current value
                 var currentValue = obj.records[cell[1]][cell[0]].style[key];
 

--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -5782,12 +5782,12 @@ var jexcel = (function(el, options) {
     /**
      * Undo last action
      */
-    obj.undo = function() {
+    obj.undo = function(OptionIgnoreEvent) {
         // Ignore events and history
         var ignoreEvents = obj.ignoreEvents ? true : false;
         var ignoreHistory = obj.ignoreHistory ? true : false;
 
-        obj.ignoreEvents = true;
+        obj.ignoreEvents = OptionIgnoreEvent == null ? true : OptionIgnoreEvent;
         obj.ignoreHistory = true;
 
         // Records
@@ -5858,12 +5858,12 @@ var jexcel = (function(el, options) {
     /**
      * Redo previously undone action
      */
-    obj.redo = function() {
+    obj.redo = function(OptionIgnoreEvent) {
         // Ignore events and history
         var ignoreEvents = obj.ignoreEvents ? true : false;
         var ignoreHistory = obj.ignoreHistory ? true : false;
 
-        obj.ignoreEvents = true;
+        obj.ignoreEvents = OptionIgnoreEvent == null ? true : OptionIgnoreEvent;
         obj.ignoreHistory = true;
 
         // Records


### PR DESCRIPTION
in function undo and redo, add option for set ignoreEvent.

When run undo or redo, i need propagation trigger event (onchange, onchangestyle, ...)

```
    /**
     * Undo last action
     */
    obj.undo = function(OptionIgnoreEvent) {
        ...
        obj.ignoreEvents = OptionIgnoreEvent == null ? true : OptionIgnoreEvent;
```

```
    /**
     * Redo previously undone action
     */
    obj.redo = function(OptionIgnoreEvent) {
        ....
        obj.ignoreEvents = OptionIgnoreEvent == null ? true : OptionIgnoreEvent;
```