### PR TITLE
Use only text for title on Cellheader

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -1070,7 +1070,7 @@ var jexcel = (function(el, options) {
         obj.headers[colNumber].setAttribute('data-x', colNumber);
         obj.headers[colNumber].style.textAlign = colAlign;
         if (obj.options.columns[colNumber].title) {
-            obj.headers[colNumber].setAttribute('title', obj.options.columns[colNumber].title);
+            obj.headers[colNumber].setAttribute('title', obj.headers[colNumber].textContent);
         }
 
         // Width control


### PR DESCRIPTION
If you use title with HTML, the title show html tag not interpreted.

For this issues, i have changed on obj.createCellHeader

```
if (obj.options.columns[colNumber].title) {
      obj.headers[colNumber].setAttribute('title', obj.options.columns[colNumber].title);
}
```

to

```
if (obj.options.columns[colNumber].title) {
        obj.headers[colNumber].setAttribute('title', obj.headers[colNumber].textContent);
}
```