### PR TITLE
Patch for issue #903

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -986,7 +986,7 @@ var jexcel = (function(el, options) {
                 obj.setValue(td, this.checked);
             }
 
-            if (obj.options.columns[i].readOnly == true) {
+            if (obj.options.columns[i].readOnly == true || obj.options.editable == false) {
                 element.setAttribute('disabled', 'disabled');
             }
 


### PR DESCRIPTION
Patch for bug to checkbox on editable option set to false.

```
    /**
     * Create cell
     */
    obj.createCell = function(i, j, value) {
        [...]
            if (obj.options.columns[i].readOnly == true || obj.options.editable == false) {
                element.setAttribute('disabled', 'disabled');
            }
```