### PR TITLE
Fix bug formula SUMIF and COUNTIF

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -12066,8 +12066,11 @@ jexcel.methods.math = (function() {
         return result;
     };
 
-    exports.SUMIF = function(range, criteria) {
-        range = utils.parseNumberArray(utils.flatten(range));
+    exports.SUMIF = function() {
+        var args = utils.argsToArray(arguments);
+        var criteria = args.pop();
+        var range = utils.parseNumberArray(utils.flatten(args));
+     
         if (range instanceof Error) {
             return range;
         }
@@ -12599,8 +12602,11 @@ jexcel.methods.stats = (function() {
         return blanks;
     };
 
-    exports.COUNTIF = function(range, criteria) {
-        range = utils.flatten(range);
+    exports.COUNTIF = function() {
+        var args = utils.argsToArray(arguments);
+        var criteria = args.pop();
+        var range = utils.flatten(args);
+     
         if (!/[<>=!]/.test(criteria)) {
             criteria = '=="' + criteria + '"';
         }


### PR DESCRIPTION
Fix bug formula in SUMIF and COUNTIF

Bug find with formula  =SUMIF(D1:D3;1) in executeFormula your expression change in

SUMIF(D1,D2,D3,1), bug the arguments of formula is SUMIF(range, criteria). Then criteria = D2

For fix that, i propose : 

```
    exports.COUNTIF = function() {
        var args = utils.argsToArray(arguments);
        var criteria = args.pop();
        var range = utils.flatten(args);
...
}
```

and 

```
 exports.SUMIF = function() {
        var args = utils.argsToArray(arguments);
        var criteria = args.pop();
        var range = utils.parseNumberArray(utils.flatten(args));
...
}
```

criteria is a last argument on formula