### PR TITLE
Fix coma interpreted on numeric input

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -1657,6 +1657,8 @@ var jexcel = (function(el, options) {
                     if (value.substr(0,1) != '=') {
                         if (value == '') {
                             value = obj.options.columns[x].allowEmpty ? '' : 0;
+                        } else {
+                            value = value.replace(/,/gi,'.');
                         }
                     }
                     cell.children[0].onblur = null;


### PR DESCRIPTION
In cell, if you write with numericpad 4,5, this is interpreted as string and not as 4.5

for change that, i propose in obj.closeEditor, add function to replace , to .

```
 obj.closeEditor = function(cell, save) {
[...]
else if (obj.options.columns[x].type == 'numeric') {
                    var value = cell.children[0].value;
                    if (value.substr(0,1) != '=') {
                        if (value == '') {
                            value = obj.options.columns[x].allowEmpty ? '' : 0;
                        } else {
                            value = value.replace(/,/gi,'.');
                        }
                    }
                    cell.children[0].onblur = null;
                }
[...]
```