### PR TITLE
fix bug for updateCell with space value

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -1970,6 +1970,10 @@ var jexcel = (function(el, options) {
                     }
                 }
             }
+         
+            if(value=='') {
+                value = obj.options.columns[x].allowEmpty ? '' : 0;
+            }
 
             // History format
             var record = {


### PR DESCRIPTION
When you press delete in cell of column with option allow empty value set to false, then in cell have writed space char and not 0.

For fix this bug, i propose add this code in obj.updateCell

```
obj.updateCell = function(x, y, value, force) {
[...]
            if(value=='') {
                value = obj.options.columns[x].allowEmpty ? '' : 0;
            }

            // History format
            var record = {
                x: x,
                y: y,
[...]
```