### PR TITLE
Fix bug display header column's on fullscreen

### DIFF
--- a/dist/jexcel.css
+++ b/dist/jexcel.css
@@ -25,6 +25,10 @@
     background-color:#ffffff;
 }
 
+.jexcel_container.with-toolbar .jexcel > thead > tr > td {
+    top: 0;
+}
+
 .jexcel_container.fullscreen.with-toolbar {
     height: calc(100% - 46px);
 }


### PR DESCRIPTION
On fullscreen with toolbar, you have header who is on 2nd row of table.

With this fix, in full screen, the headers is fix on top behind toolbar