### PR TITLE
Added optional id attribute to toolbar buttons

### DIFF
--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -1310,6 +1310,10 @@ console.log(ret);
                 toolbarItem.classList.add('material-icons');
                 toolbarItem.setAttribute('data-k', toolbar[i].k);
                 toolbarItem.setAttribute('data-v', toolbar[i].v);
+                // optionally add an ID for css or whatever
+                if (toolbar[i].hasOwnProperty('id')) {
+                    toolbarItem.setAttribute('id', toolbar[i].id);
+                }
                 // Tooltip
                 if (toolbar[i].tooltip) {
                     toolbarItem.setAttribute('title', toolbar[i].tooltip);


### PR DESCRIPTION
This will more easily allow better customization of toolbar buttons with css.  If an id property exists for an element of type i, then an attribute is set in the generated html.  If id property doesn't exist, nothing happens.