### PR TITLE
Fix for CSV Export files break when headers contain new line characters

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5915,7 +5915,7 @@
                 // Data
                 var data = '';
                 if (includeHeaders == true || obj.options.includeHeadersOnDownload == true) {
-                    data += obj.getHeaders();
+                    data += obj.getHeaders().replace(/\s+/gm,' ');
                     data += "\r\n";
                 }
 


### PR DESCRIPTION
If a column header contains a new line (which we use to keep column widths narrow), then the exported CSV files contain new lines in their headings which breaks the CSV format.   This fix replaces all whitespace characters and multiple whitespace strings with single spaces to fix that.