### PR TITLE
Fix for issue #1192

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -3628,9 +3628,9 @@
                         var valueB = b[p];
 
                         if (! o) {
-                            return (valueA == '' && valueB != '') ? 1 : (valueA != '' && valueB == '') ? -1 : (valueA > valueB) ? 1 : (valueA < valueB) ? -1 :  0;
+                            return (valueA === '' && valueB !== '') ? 1 : (valueA !== '' && valueB === '') ? -1 : (valueA > valueB) ? 1 : (valueA < valueB) ? -1 :  0;
                         } else {
-                            return (valueA == '' && valueB != '') ? 1 : (valueA != '' && valueB == '') ? -1 : (valueA > valueB) ? -1 : (valueA < valueB) ? 1 :  0;
+                            return (valueA === '' && valueB !== '') ? 1 : (valueA !== '' && valueB === '') ? -1 : (valueA > valueB) ? -1 : (valueA < valueB) ? 1 :  0;
                         }
                     });
                 }


### PR DESCRIPTION
When cell value is 0 and type is number, strict equality check must be enforced for correct type of sorting. Loose equality put 0 at the end of the table whether it is ascending or descending.