### PR TITLE
CSV Export files break when headers contain new line characters

### DIFF
--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5943,7 +5943,7 @@ if (! jSuites && typeof(require) === 'function') {
                 // Data
                 var data = '';
                 if (includeHeaders == true || obj.options.includeHeadersOnDownload == true) {
-                    data += obj.getHeaders();
+                    data += obj.getHeaders().replace(/\s+/gm,' ');
                     data += "\r\n";
                 }
 

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -8,7 +8,7 @@
  * This software is distribute under MIT License
  */
 
- if (! jSuites && typeof(require) === 'function') {
+if (! jSuites && typeof(require) === 'function') {
     var jSuites = require('jsuites');
     require('jsuites/dist/jsuites.css');
 }
@@ -1696,19 +1696,24 @@
                 // Reset selection
                 obj.resetSelection();
                 // Load options
-                var options = [];
-                for (var j = 0; j < obj.options.data.length; j++) {
-                    var k = obj.options.data[j][columnId];
-                    var v = obj.records[j][columnId].innerHTML;
-                    if (k && v) {
-                        options[k] = v;
-                    }
-                }
-                var keys = Object.keys(options);
                 var optionsFiltered = [];
-                optionsFiltered.push({ id: '', name: 'Blanks' });
-                for (var j = 0; j < keys.length; j++) {
-                    optionsFiltered.push({ id: keys[j], name: options[keys[j]] });
+                if (obj.options.columns[columnId].type == 'checkbox') {
+                    optionsFiltered.push({ id: 'false', name: '<input type=checkbox unchecked disabled>'});
+                    optionsFiltered.push({ id: 'true', name: '<input type=checkbox checked disabled>' });
+                } else {
+                    var options = [];
+                    for (var j = 0; j < obj.options.data.length; j++) {
+                        var k = obj.options.data[j][columnId];
+                        var v = obj.records[j][columnId].innerHTML;
+                        if (k && v) {
+                            options[k] = v;
+                        }
+                    }
+                    var keys = Object.keys(options);
+                    optionsFiltered.push({ id: '', name: '(Blanks)' });
+                    for (var j = 0; j < keys.length; j++) {
+                        optionsFiltered.push({ id: keys[j], name: options[keys[j]] });
+                    }
                 }
 
                 // Create dropdown
@@ -1765,7 +1770,7 @@
             var search = function(query, x, y) {
                 for (var i = 0; i < query.length; i++) {
                     if (query[i] == '') {
-                        if (obj.options.data[y][x] == '') {
+                        if (''+obj.options.data[y][x] == '' || obj.options.data[y][x] === false) {
                             return true;
                         }
                     } else {
@@ -1779,14 +1784,15 @@
             }
 
             var query = obj.filters[columnId];
-            obj.results = [];
-            for (var j = 0; j < obj.options.data.length; j++) {
-                if (search(query, columnId, j)) {
-                    obj.results.push(j);
-                }
-            }
-            if (! obj.results.length) {
+            if (query.length == 0) {
                 obj.results = null;
+            } else {
+                obj.results = [];
+                for (var j = 0; j < obj.options.data.length; j++) {
+                    if (search(query, columnId, j)) {
+                        obj.results.push(j);
+                    }
+                }
             }
 
             obj.updateResult();

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -453,7 +453,6 @@
                     }
                 }
             }
-
             // Create the table when is ready
             if (! multiple.length) {
                 obj.createTable();
@@ -1023,7 +1022,6 @@
         obj.save = function(url, data) {
             // Parse anything in the data before sending to the server
             var ret = obj.dispatch('onbeforesave', el, obj, data);
-
             if (ret) {
                 var data = ret;
             } else {
@@ -1265,7 +1263,6 @@
                     }
                 }
             }
-
             return td;
         }
     
@@ -1367,7 +1364,6 @@
             } else {
                 var toolbar = obj.options.toolbar;
             }
-
             for (var i = 0; i < toolbar.length; i++) {
                 if (toolbar[i].type == 'i') {
                     var toolbarItem = document.createElement('i');
@@ -2312,7 +2308,6 @@
                 obj.onafterchanges(el, records);
             }
         }
-
         /**
          * Strip tags
          */
@@ -3655,7 +3650,6 @@
                     return this.slice(0).sort(function(a, b) {
                         var valueA = a[p];
                         var valueB = b[p];
-
                         if (! o) {
                             return (valueA == '' && valueB != '') ? 1 : (valueA != '' && valueB == '') ? -1 : (valueA > valueB) ? 1 : (valueA < valueB) ? -1 :  0;
                         } else {
@@ -3663,7 +3657,6 @@
                         }
                     });
                 }
-
                 // Test order
                 var temp = [];
                 if (obj.options.columns[column].type == 'number' || obj.options.columns[column].type == 'percentage' || obj.options.columns[column].type == 'autonumber' || obj.options.columns[column].type == 'color') {

--- a/dist/jexcel.js
+++ b/dist/jexcel.js
@@ -5915,7 +5915,7 @@
                 // Data
                 var data = '';
                 if (includeHeaders == true || obj.options.includeHeadersOnDownload == true) {
-                    data += obj.getHeaders();
+                    data += obj.getHeaders().replace(/\s+/gm,' ');
                     data += "\r\n";
                 }
 


### PR DESCRIPTION
If a column header contains a new line (which we use to keep column widths narrow), then the exported CSV files contain new lines in their headings which breaks the CSV format.   This fix replaces all whitespace characters and multiple whitespace strings with single spaces to fix that.

(rebase of #1197)