### PR TITLE
Fix right-click selection behaviour

### DIFF
--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -7887,6 +7887,12 @@ jexcel.contextMenuControls = function(e) {
                 var y = e.target.getAttribute('data-y');
 
                 if (x || y) {
+                    if ((x < parseInt(jexcel.current.selectedCell[0])) || (x > parseInt(jexcel.current.selectedCell[2])) ||
+                        (y < parseInt(jexcel.current.selectedCell[1])) || (y > parseInt(jexcel.current.selectedCell[3])))
+                    {
+                        jexcel.current.updateSelectionFromCoords(x, y, x, y);
+                    }
+
                     // Table found
                     var items = jexcel.current.options.contextMenu(jexcel.current, x, y, e);
                     // The id is depending on header and body


### PR DESCRIPTION
In my humble opinion, the right-click behaviour of jExcel might cause some misunderstanding.  
When you right-click on a cell, it keeps the last selected cell selected.

In some cases, it can cause problems.

With this PR, I've implemented the standard behaviour from others spreadsheet programs.  
If you right-click on the selection (one or more cells), the selection will remain as is...  
If you right-click outside from the selection, the new cell (the one you clicked) will be selected.