### PR TITLE
Update jexcel.extensions.js

### DIFF
--- a/src/js/jexcel.extensions.js
+++ b/src/js/jexcel.extensions.js
@@ -374,7 +374,7 @@ jexcel.createFromTable = function(el, options) {
         var rows = {};
         var style = {};
 
-        var content = el.querySelectorAll('table > tr, tbody tr');
+        var content = el.querySelectorAll(':scope > tr, :scope > tbody > tr');
         for (var j = 0; j < content.length; j++) {
             options.data[rowNumber] = [];
             if (options.parseTableFirstRowAsHeader == true && j == 0) {


### PR DESCRIPTION
Fixes issue #1238: the query selector for locating spreadsheet rows has been modified such that it works strictly within the scope of the spreadsheet generated by the plugin. This is important when a static HTML table is converted into a spreadsheet and the table contains nested tables. Previously, nested tables were breaking the spreadsheet layout, introducing seemingly arbitrary rows and cells into the spreadsheet, causing confusion for the users.