### PR TITLE
Fix error when undoing row deletion

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6325,7 +6325,7 @@ if (! jSuites && typeof(require) === 'function') {
          * Process row
          */
         obj.historyProcessRow = function(type, historyRecord) {
-            var rowIndex = (! historyRecord.insertBefore) ? historyRecord.rowNumber + 1 : historyRecord.rowNumber;
+            var rowIndex = (! historyRecord.insertBefore) ? historyRecord.rowNumber + 1 : +historyRecord.rowNumber;
     
             if (obj.options.search == true) {
                 if (obj.results && obj.results.length != obj.rows.length) {

--- a/src/compile.php
+++ b/src/compile.php
@@ -4,6 +4,7 @@ if ($handle = opendir('js')) {
     $js = '';
     $css = '';
     while (false !== ($entry = readdir($handle))) {
+        echo "reading { $entry }\n";
         if ($entry != "." && $entry != ".." && (! isset($modules) || in_array(substr($entry, 0, strpos($entry, '.')), $modules))) {
             $js .= file_get_contents('js/'.$entry) . "\r\n\r\n";
         }
@@ -39,5 +40,5 @@ $js
 
 })));";
 
-    file_put_contents('../dist/jexcel.js', $js);
+    file_put_contents('../dist/index.js', $js);
 }

--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -6285,7 +6285,7 @@ var jexcel = (function(el, options) {
      * Process row
      */
     obj.historyProcessRow = function(type, historyRecord) {
-        var rowIndex = (! historyRecord.insertBefore) ? historyRecord.rowNumber + 1 : historyRecord.rowNumber;
+        var rowIndex = (! historyRecord.insertBefore) ? historyRecord.rowNumber + 1 : +historyRecord.rowNumber;
 
         if (obj.options.search == true) {
             if (obj.results && obj.results.length != obj.rows.length) {


### PR DESCRIPTION
Currently, when you remove a row through a call to `deleteRow`, and try to restore it with a Ctrl+Z, you get this error :

```
Uncaught TypeError: Failed to execute 'insertBefore' on 'Node': parameter 1 is not of type 'Node'.
    at Object.obj.historyProcessRow (index.js?e503:6357)
    at Object.obj.undo (index.js?e503:6479)
    at HTMLDocument.jexcel.keyDownControls (index.js?e503:7268)
```

[The error occurs here](https://github.com/jspreadsheet/ce/blob/81cd99aeb5b694bbc20765a172afb21f2ca8163f/dist/index.js#L6357)

I also left a small correction to compile.php, because I think this is an oversight of the recent renaming.