### PR TITLE
Ignore pasted data that overflows when allowInsertColumn or allowInsertRow is false

### DIFF
--- a/src/js/jexcel.core.js
+++ b/src/js/jexcel.core.js
@@ -6227,7 +6227,13 @@ var jexcel = (function(el, options) {
                     i++;
                     if (row[i] != null) {
                         if (colIndex >= obj.headers.length - 1) {
-                            obj.insertColumn();
+                            // If the pasted column is out of range, create it if possible
+                            if (obj.options.allowInsertColumn == true) {
+                                obj.insertColumn();
+                            // Otherwise skip the pasted data that overflows
+                            } else {
+                                break;
+                            }
                         }
                         colIndex = obj.right.get(colIndex, rowIndex);
                     }
@@ -6236,7 +6242,13 @@ var jexcel = (function(el, options) {
                 j++;
                 if (data[j]) {
                     if (rowIndex >= obj.rows.length-1) {
-                        obj.insertRow();
+                        // If the pasted row is out of range, create it if possible
+                        if (obj.options.allowInsertRow == true) {
+                            obj.insertRow();
+                        // Otherwise skip the pasted data that overflows
+                        } else {
+                            break;
+                        }
                     }
                     rowIndex = obj.down.get(x, rowIndex);
                 }


### PR DESCRIPTION
When pasting some tabular CSV that is larger or longer than the current spreadsheet, and when **inserting a column or row is not allowed**, the last cell keeps getting updated with the overflowing data. As a result, the last cell contains the last value of the pasted data.

That is if I paste the values A B C D on a row with three fixed columns, the three cells contain A, B and D after pasting.

This PR fixes that behavior so that the cells contain A, B and C after pasting.