### PR TITLE
faster paste

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6505,7 +6505,8 @@ if (! jSuites && typeof(require) === 'function') {
                         if (rowIndex >= obj.rows.length-1) {
                             // If the pasted row is out of range, create it if possible
                             if (obj.options.allowInsertRow == true) {
-                                obj.insertRow();
+                                // Insert all required rows at once instead
+                                obj.insertRow(data.length - (rowIndex - y) - 1);
                                 // Otherwise skip the pasted data that overflows
                             } else {
                                 break;


### PR DESCRIPTION
When pasting a lot of rows and these rows need to be created, performance can be quite poor.
By inserting all new rows at once, a speed gain of ~x5 is gained when inserting 100 new rows (750ms - 150ms)

(this is my first pull request, apologies if this is not according to the guidelines)