### PR TITLE
Fix recognition of new rows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6660,6 +6660,9 @@ if (! jSuites && typeof(require) === 'function') {
 
             // Load data
             obj.setData();
+            
+            // Extracted from setData()
+            obj.initializeHistory();
 
             // Style
             if (obj.options.style) {
@@ -6698,6 +6701,10 @@ if (! jSuites && typeof(require) === 'function') {
                         obj.options.data = (result.data) ? result.data : result;
                         // Prepare table
                         obj.setData();
+                        
+                        // Extracted from setData()
+                        obj.initializeHistory();
+                        
                         // Hide spin
                         if (obj.options.loadingSpin == true) {
                             jSuites.loading.hide();
@@ -6706,6 +6713,9 @@ if (! jSuites && typeof(require) === 'function') {
                 });
             } else {
                 obj.setData();
+                
+                // Extracted from setData()
+                obj.initializeHistory();
             }
         }
 
@@ -6772,11 +6782,16 @@ if (! jSuites && typeof(require) === 'function') {
             obj.rows = [];
             obj.results = null;
             obj.records = [];
+            
+            // Extracted to the initializeHistory function
+            /*
             obj.history = [];
 
             // Reset internal controllers
             obj.historyIndex = -1;
-
+            */
+            
+            
             // Reset data
             obj.tbody.innerHTML = '';
 
@@ -10661,6 +10676,9 @@ if (! jSuites && typeof(require) === 'function') {
          * @return void
          */
         obj.updateTableReferences = function() {
+           
+            obj.setData();
+            
             // Update headers
             for (var i = 0; i < obj.headers.length; i++) {
                 var x = obj.headers[i].getAttribute('data-x');
@@ -12111,6 +12129,22 @@ if (! jSuites && typeof(require) === 'function') {
                 obj.history[index] = changes;
             }
         }
+                
+        /**
+         *
+         * Initializes the controllers of history/undo
+         *
+         * @return null
+         */
+        obj.initializeHistory = function() {
+            
+            // Initialize history/undo 
+            obj.history = [];
+
+            // Reset internal controllers
+            obj.historyIndex = -1;
+           
+        }
 
         /**
          * Copy method
@@ -12650,6 +12684,9 @@ if (! jSuites && typeof(require) === 'function') {
             obj.ignoreEvents = ignoreEvents;
             obj.ignoreHistory = ignoreHistory;
 
+            // Force the recognition of new lines
+            obj.setData();
+            
             // Events
             obj.dispatch('onundo', el, historyRecord);
         }
@@ -12716,6 +12753,9 @@ if (! jSuites && typeof(require) === 'function') {
             }
             obj.ignoreEvents = ignoreEvents;
             obj.ignoreHistory = ignoreHistory;
+            
+            // Force the recognition of new lines
+            obj.setData();
 
             // Events
             obj.dispatch('onredo', el, historyRecord);


### PR DESCRIPTION
#1547 

When new rows are added, they are not recognized by the spreadsheet, bringing bad behaviors like: if we have a formula with a range and we add a new intermediate row in this range, the new row is not recognized by the formula; if we have a column that is hidden by hideColumn() and we add a row and then set a value to this hidden column, the content is showed on visible column by the side like innerHTML. After call setData, the spreadsheet works nice. So, I removed the part of initialize the history container and controller, cleaning the setData from this scope, creating a new function initializeHistory and distribuiting together with setData over the code, to keep funcionality and place the setData over updateTableReferences(), undo() and redo()