### PR TITLE
Bugfix: Fix spacebar clear selected

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13342,11 +13342,6 @@ if (! jSuites && typeof(require) === 'function') {
                 } else if (e.which == 35) {
                     jexcel.current.last(e.shiftKey, e.ctrlKey);
                     e.preventDefault();
-                } else if (e.which == 32) {
-                    if (jexcel.current.options.editable == true) {
-                        jexcel.current.setCheckRadioValue();
-                    }
-                    e.preventDefault();
                 } else if (e.which == 46) {
                     // Delete
                     if (jexcel.current.options.editable == true) {
@@ -13445,14 +13440,22 @@ if (! jSuites && typeof(require) === 'function') {
                                 if (jexcel.current.options.columns[columnId].type != 'readonly') {
                                     // Characters able to start a edition
                                     if (e.keyCode == 32) {
-                                        // Space
-                                        if (jexcel.current.options.columns[columnId].type == 'checkbox' ||
-                                            jexcel.current.options.columns[columnId].type == 'radio') {
-                                            e.preventDefault();
-                                        } else {
-                                            // Start edition
-                                            jexcel.current.openEditor(jexcel.current.records[rowId][columnId], true);
-                                        }
+                                      // Space
+                                      e.preventDefault()
+                                      if (
+                                        jspreadsheet.current.options.columns[columnId].type ==
+                                          'checkbox' ||
+                                        jspreadsheet.current.options.columns[columnId].type ==
+                                          'radio'
+                                      ) {
+                                        jspreadsheet.current.setCheckRadioValue()
+                                      } else {
+                                        // Start edition
+                                        jspreadsheet.current.openEditor(
+                                          jspreadsheet.current.records[rowId][columnId],
+                                          true,
+                                        )
+                                      }
                                     } else if (e.keyCode == 113) {
                                         // Start edition with current content F2
                                         jexcel.current.openEditor(jexcel.current.records[rowId][columnId], false);

--- a/dist/index.js
+++ b/dist/index.js
@@ -13443,10 +13443,8 @@ if (! jSuites && typeof(require) === 'function') {
                                             // Space
                                             e.preventDefault()
                                             if (
-                                                jspreadsheet.current.options.columns[columnId].type ==
-                                                'checkbox' ||
-                                                jspreadsheet.current.options.columns[columnId].type ==
-                                                'radio'
+                                                jspreadsheet.current.options.columns[columnId].type == 'checkbox' ||
+                                                jspreadsheet.current.options.columns[columnId].type == 'radio'
                                             ) {
                                                 jspreadsheet.current.setCheckRadioValue()
                                             } else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9364,7 +9364,7 @@ if (! jSuites && typeof(require) === 'function') {
                             td.style.textAlign = colAlign;
                         }
                         td.innerText = obj.parseValue(+obj.records.length + i, j, obj.options.footers[j][i]);
-                        
+
                         // Hide/Show with hideColumn()/showColumn()
                         td.style.display = obj.colgroup[i].style.display;
                     }
@@ -10903,12 +10903,12 @@ if (! jSuites && typeof(require) === 'function') {
             for (var j = 0; j < obj.options.data.length; j++) {
                 obj.records[j][colNumber].style.display = '';
             }
-            
+
             // Update footers
             if (obj.options.footers) {
                 obj.setFooter();
             }
-            
+
             obj.resetSelection();
         }
 
@@ -10924,12 +10924,12 @@ if (! jSuites && typeof(require) === 'function') {
             for (var j = 0; j < obj.options.data.length; j++) {
                 obj.records[j][colNumber].style.display = 'none';
             }
-            
+
             // Update footers
             if (obj.options.footers) {
                 obj.setFooter();
             }
-            
+
             obj.resetSelection();
         }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -13436,27 +13436,27 @@ if (! jSuites && typeof(require) === 'function') {
                                 var rowId = jexcel.current.selectedCell[1];
                                 var columnId = jexcel.current.selectedCell[0];
 
-                                // If is not readonly
-                                if (jexcel.current.options.columns[columnId].type != 'readonly') {
-                                    // Characters able to start a edition
-                                    if (e.keyCode == 32) {
-                                      // Space
-                                      e.preventDefault()
-                                      if (
-                                        jspreadsheet.current.options.columns[columnId].type ==
-                                          'checkbox' ||
-                                        jspreadsheet.current.options.columns[columnId].type ==
-                                          'radio'
-                                      ) {
-                                        jspreadsheet.current.setCheckRadioValue()
-                                      } else {
-                                        // Start edition
-                                        jspreadsheet.current.openEditor(
-                                          jspreadsheet.current.records[rowId][columnId],
-                                          true,
-                                        )
-                                      }
-                                    } else if (e.keyCode == 113) {
+                                    // If is not readonly
+                                    if (jexcel.current.options.columns[columnId].type != 'readonly') {
+                                        // Characters able to start a edition
+                                        if (e.keyCode == 32) {
+                                            // Space
+                                            e.preventDefault()
+                                            if (
+                                                jspreadsheet.current.options.columns[columnId].type ==
+                                                'checkbox' ||
+                                                jspreadsheet.current.options.columns[columnId].type ==
+                                                'radio'
+                                            ) {
+                                                jspreadsheet.current.setCheckRadioValue()
+                                            } else {
+                                                // Start edition
+                                                jspreadsheet.current.openEditor(
+                                                    jspreadsheet.current.records[rowId][columnId],
+                                                    true,
+                                                )
+                                            }
+                                        } else if (e.keyCode == 113) {
                                         // Start edition with current content F2
                                         jexcel.current.openEditor(jexcel.current.records[rowId][columnId], false);
                                     } else if ((e.keyCode == 8) ||


### PR DESCRIPTION
There was redundant logic preventing the Spacebar from clearing a cell and then entering it on non-Radio/Checkbox cell types. This PR fixes that bug; the spacebar now correctly clears and enters selected non-Radio/Checkbox cells, while still toggling radio/checkbox cells.