### PR TITLE
bugfix/toolbar icon item missing id typedefinition

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -251,6 +251,7 @@ declare namespace jspreadsheet {
   }
 
   interface ToolbarIconItem extends ToolbarItemBase {
+    id: string;
     type: "i";
 
     /** Defines the icon (from material icons). */


### PR DESCRIPTION
This pull request closes the Issue: https://github.com/jspreadsheet/ce/issues/1601
It adds the missing id attribute to the ToolbarIconItem-Type.

You see that the id attribute exists on index.js line 7400
