### PR TITLE
fix event handler for space key

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13452,12 +13452,12 @@ if (! jSuites && typeof(require) === 'function') {
                                     if (e.keyCode == 32) {
                                         // Space
                                         e.preventDefault()
-                                        if (jspreadsheet.current.options.columns[columnId].type == 'checkbox' ||
-                                            jspreadsheet.current.options.columns[columnId].type == 'radio') {
-                                            jspreadsheet.current.setCheckRadioValue();
+                                        if (jexcel.current.options.columns[columnId].type == 'checkbox' ||
+                                            jexcel.current.options.columns[columnId].type == 'radio') {
+                                            jexcel.current.setCheckRadioValue();
                                         } else {
                                             // Start edition
-                                            jspreadsheet.current.openEditor(jspreadsheet.current.records[rowId][columnId], true);
+                                            jexcel.current.openEditor(jexcel.current.records[rowId][columnId], true);
                                         }
                                     } else if (e.keyCode == 113) {
                                         // Start edition with current content F2


### PR DESCRIPTION
resolves #1603

The event handler for "space" key press references the global object as `jspreadsheet` although it is internally only available as `jexcel`. This causes the following error, when a user presses the space key:

```
index.js:13455 Uncaught ReferenceError: jspreadsheet is not defined
    at jexcel.keyDownControls (index.js:13455:1)
jexcel.keyDownControls @ index.js:13455
```

#1607 also references this issue, but it appears that PR formatted all of `dist/index.js`.