### PR TITLE
[fix] - Allow multiple cell erase on backspace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7483,7 +7483,7 @@ if (! formula && typeof(require) === 'function') {
                 } else if (e.which == 35) {
                     jexcel.current.last(e.shiftKey, e.ctrlKey);
                     e.preventDefault();
-                } else if (e.which == 46 || e.which == 6) {
+                } else if (e.which == 46 || e.which == 8) {
                     // Delete
                     if (jexcel.current.options.editable == true) {
                         if (jexcel.current.selectedRow) {

--- a/src/index.js
+++ b/src/index.js
@@ -7483,7 +7483,7 @@ if (! formula && typeof(require) === 'function') {
                 } else if (e.which == 35) {
                     jexcel.current.last(e.shiftKey, e.ctrlKey);
                     e.preventDefault();
-                } else if (e.which == 46) {
+                } else if (e.which == 46 || e.which == 6) {
                     // Delete
                     if (jexcel.current.options.editable == true) {
                         if (jexcel.current.selectedRow) {


### PR DESCRIPTION
### Context 

I use jspreasheet to edit d3 charts data. I am running the project on a macbook pro.

### Problem

I was unable to erase values from multiple cells at once (multiple selection). I tried first on my app :
```js
onKeydown (e) {
  if (!this.spreadsheet) return

  if (e.code === 'Backspace') {
     const highlighted = this.spreadsheet.getHighlighted()
     if (highlighted.length && highlighted.length > 1) {
       highlighted.forEach((cell) => {
        this.spreadsheet.setValue(cell, '')
       })
    }
  }
},
```

But it resulted on an error `cell.children[0] is undefined` on the `keydownControls` function. Because no inputs were available on the table.

### Fix

Add `backspace` key to the `delete` key condition