### PR TITLE
add null type to contextMenu in options

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -607,7 +607,7 @@ declare namespace jspreadsheet {
       colIndex: string | null,
       rowIndex: string | null,
       event: PointerEvent
-    ) => object[];
+    ) => object[] | null;
 
     /**
      * If true, copy and export will bring formula results. If false, it will bring formulas.


### PR DESCRIPTION
Adding `null` type to `contextMenu` in `JSpreadsheetOptions`.