### PR TITLE
Fix selection frame to appear on hidden column after showColumn() 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3079,7 +3079,7 @@ if (! formula && typeof(require) === 'function') {
                     borderRight = 0;
                 }
                 for (var i = borderLeft; i <= borderRight; i++) {
-                    if (obj.options.columns[i].type != 'hidden') {
+                    if (obj.options.columns[i].type != 'hidden' && obj.colgroup[i].style && obj.colgroup[i].style.display != 'none') {
                         // Top border
                         if (obj.records[borderTop] && obj.records[borderTop][i]) {
                             obj.records[borderTop][i].classList.add('highlight-top');


### PR DESCRIPTION
When using hideColumn() to hide a column, selecting a row, and then executing showColumn(), a bold line appears on the column that was hidden. Upon investigation, it was discovered that this issue arises because the highlight-top and highlight-bottom classes are being added, despite the corresponding cell in the hidden column not being pushed to obj.highlighted.

I believe it is necessary to add a condition not only for obj.options.columns[i].type != 'hidden' but also for obj.colgroup[i].style.display != 'none', so I have incorporated it.

I am reopening this pull request as I mistakenly created one against the dev branch earlier. My apologies for any inconvenience.

Please review and let me know if there are any questions or if further clarification is needed.
Thank you.