### PR TITLE
Fix for bug encountered when using column numbers exceeding 1351 columns

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8554,17 +8554,18 @@ if (! formula && typeof(require) === 'function') {
      * @param integer i
      * @return string letter
      */
-    jexcel.getColumnName = function(i) {
-        var letter = '';
-        if (i > 701) {
-            letter += String.fromCharCode(64 + parseInt(i / 676));
-            letter += String.fromCharCode(64 + parseInt((i % 676) / 26));
-        } else if (i > 25) {
-            letter += String.fromCharCode(64 + parseInt(i / 26));
-        }
-        letter += String.fromCharCode(65 + (i % 26));
-
-        return letter;
+    jexcel.getColumnName = function (columnNumber){
+        var dividend = columnNumber+1;
+        var columnName = "";
+        var modulo;
+    
+        while (dividend > 0)
+        {
+            modulo = (dividend - 1) % 26;
+            columnName = String.fromCharCode(65 + modulo).toString() + columnName;
+            dividend = parseInt((dividend - modulo) / 26);
+        } 
+        return  columnName;
     }
 
     /**
@@ -8938,17 +8939,18 @@ if (! formula && typeof(require) === 'function') {
          * @param integer i
          * @return string letter
          */
-        component.getColumnName = function(i) {
-            var letter = '';
-            if (i > 701) {
-                letter += String.fromCharCode(64 + parseInt(i / 676));
-                letter += String.fromCharCode(64 + parseInt((i % 676) / 26));
-            } else if (i > 25) {
-                letter += String.fromCharCode(64 + parseInt(i / 26));
-            }
-            letter += String.fromCharCode(65 + (i % 26));
-
-            return letter;
+        component.getColumnName = function (columnNumber){
+            var dividend = columnNumber+1;
+            var columnName = "";
+            var modulo;
+        
+            while (dividend > 0)
+            {
+                modulo = (dividend - 1) % 26;
+                columnName = String.fromCharCode(65 + modulo).toString() + columnName;
+                dividend = parseInt((dividend - modulo) / 26);
+            } 
+            return  columnName;
         }
 
         /**


### PR DESCRIPTION
#### Description
For columns exceeding 1352, the current method for converting column number to a letter combination will issue B@A to B@Z, instead of the expected AZA to AZZ. This fix fixes the specific column range 1352 to 1377 - I dont have the time to test for columns beyond this, but programmatically I think it fixes it.

#### Steps to Reproduce
Use any tabular functionality with more than 1352 columns.

#### Fix
Modify the "getColumnName" functions in index.ts

#### Summary
Columns 1352 -> 1377 will no longer issue funny naming, (B@A -> B@Z), and wont mess up formulas and so on.

