### PR TITLE
Delete keydown handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7537,6 +7537,7 @@ if (! formula && typeof(require) === 'function') {
                             jexcel.current.setValue(jexcel.current.highlighted, '');
                         }
                     }
+                    e.preventDefault();
                 } else if (e.which == 13) {
                     // Move cursor
                     if (e.shiftKey) {


### PR DESCRIPTION
If you use the copy, paste and del function using only the keyboard the window scroll to top. 
This change fix the bug