### PR TITLE
Improve large data paste for v5

### DIFF
--- a/src/utils/copyPaste.js
+++ b/src/utils/copyPaste.js
@@ -1,7 +1,7 @@
 import { parseCSV } from "./helpers.js";
 import dispatch from "./dispatch.js";
 import { setHistory } from "./history.js";
-import { updateCell, updateFormulaChain, updateTable } from "./internal.js";
+import { updateCell, updateFormulaChain, updateTable, updateTableReferences } from "./internal.js";
 import { downGet, rightGet } from "./keys.js";
 import { hash, removeCopyingSelection, updateSelectionFromCoords } from "./selection.js";
 import { getColumnNameFromId } from "./internalHelpers.js";
@@ -221,7 +221,9 @@ export const copy = function(highlighted, delimiter, returnData, includeHeaders,
 /**
  * Jspreadsheet paste method
  *
- * @param integer row number
+ * @param x target column
+ * @param y target row
+ * @param data paste data. if data hash is the same as the copied data, apply style from copied cells  
  * @return string value
  */
 export const paste = function(x, y, data) {
@@ -229,7 +231,7 @@ export const paste = function(x, y, data) {
 
     // Controls
     const dataHash = hash(data);
-    const style = (dataHash == obj.hashString) ? obj.style : null;
+    let style = (dataHash == obj.hashString) ? obj.style : null;
 
     // Depending on the behavior
     if (dataHash == obj.hashString) {
@@ -238,6 +240,51 @@ export const paste = function(x, y, data) {
 
     // Split new line
     data = parseCSV(data, "\t");
+
+    const ex = obj.selectedCell[2];
+    const ey = obj.selectedCell[3];
+
+    const w = ex - x + 1;
+    const h = ey - y + 1;
+
+    // Modify data to allow wor extending paste range in multiples of input range
+    const srcW = data[0].length;
+    if ((w > 1) & Number.isInteger(w / srcW)) {
+        const repeats = w / srcW;
+        if( style ){
+            const newStyle = [];
+            for(let i=0 ;i <style.length ; i+=srcW ){
+                const chunk = style.slice(i,i+srcW);
+                for (let j = 0; j < repeats; j++) {
+                    newStyle.push(...chunk);
+                }
+            }
+            style = newStyle;
+        };
+
+        const arrayB = data.map(function (row, i) {
+            const arrayC = Array.apply(null, { length: repeats * row.length }).map(
+                function (e, i) { return row[i % row.length]; }
+            );
+            return arrayC;
+        });
+        data = arrayB;
+    }
+    const srcH = data.length;
+    if ((h > 1) & Number.isInteger(h / srcH)) {
+        const repeats = h / srcH;
+        if( style ){
+            const newStyle = [];
+            for (let j = 0; j < repeats; j++) {
+                newStyle.push(...style);
+            }
+            style = newStyle;
+        };
+        const arrayB = Array.apply(null, { length: repeats * srcH }).map(
+            function (e, i) { return data[i % srcH]; }
+        );
+        data = arrayB;
+    }
 
     // Paste filter
     const ret = dispatch.call(
@@ -272,6 +319,26 @@ export const paste = function(x, y, data) {
         let colIndex = parseInt(x);
         let rowIndex = parseInt(y);
         let row = null;
+
+        const hiddenColCount = obj.headers.filter(x=>x.style.display === 'none').length;
+        const expandedColCount = colIndex + hiddenColCount + data[0].length;
+        const currentColCount = obj.headers.length;
+        if( expandedColCount > currentColCount){
+            obj.skipUpdateTableReferences = true;
+            obj.insertColumn( expandedColCount - currentColCount);
+        }
+        const hiddenRowCount = obj.rows.filter(x=>x.element.style.display === 'none').length;
+        const expandedRowCount = rowIndex + hiddenRowCount + data.length;
+        const currentRowCount = obj.rows.length;
+        if( expandedRowCount > currentRowCount){
+            obj.skipUpdateTableReferences = true;
+            obj.insertRow( expandedRowCount - currentRowCount);
+        }
+
+        if( obj.skipUpdateTableReferences ){
+            obj.skipUpdateTableReferences = false;
+            updateTableReferences.call(obj);
+        }
 
         // Go through the columns to get the data
         while (row = data[j]) {

--- a/src/utils/copyPaste.js
+++ b/src/utils/copyPaste.js
@@ -320,14 +320,14 @@ export const paste = function(x, y, data) {
         let rowIndex = parseInt(y);
         let row = null;
 
-        const hiddenColCount = obj.headers.slice(colIndex, colIndex + data[0].length).filter(x=>x.style.display === 'none').length;
+        const hiddenColCount = obj.headers.slice(colIndex).filter(x=>x.style.display === 'none').length;
         const expandedColCount = colIndex + hiddenColCount + data[0].length;
         const currentColCount = obj.headers.length;
         if( expandedColCount > currentColCount){
             obj.skipUpdateTableReferences = true;
             obj.insertColumn( expandedColCount - currentColCount);
         }
-        const hiddenRowCount = obj.rows.slice(colIndex, colIndex + data.length).filter(x=>x.element.style.display === 'none').length;
+        const hiddenRowCount = obj.rows.slice(rowIndex).filter(x=>x.element.style.display === 'none').length;
         const expandedRowCount = rowIndex + hiddenRowCount + data.length;
         const currentRowCount = obj.rows.length;
         if( expandedRowCount > currentRowCount){

--- a/src/utils/copyPaste.js
+++ b/src/utils/copyPaste.js
@@ -320,14 +320,14 @@ export const paste = function(x, y, data) {
         let rowIndex = parseInt(y);
         let row = null;
 
-        const hiddenColCount = obj.headers.filter(x=>x.style.display === 'none').length;
+        const hiddenColCount = obj.headers.slice(colIndex, colIndex + data[0].length).filter(x=>x.style.display === 'none').length;
         const expandedColCount = colIndex + hiddenColCount + data[0].length;
         const currentColCount = obj.headers.length;
         if( expandedColCount > currentColCount){
             obj.skipUpdateTableReferences = true;
             obj.insertColumn( expandedColCount - currentColCount);
         }
-        const hiddenRowCount = obj.rows.filter(x=>x.element.style.display === 'none').length;
+        const hiddenRowCount = obj.rows.slice(colIndex, colIndex + data.length).filter(x=>x.element.style.display === 'none').length;
         const expandedRowCount = rowIndex + hiddenRowCount + data.length;
         const currentRowCount = obj.rows.length;
         if( expandedRowCount > currentRowCount){

--- a/src/utils/internal.js
+++ b/src/utils/internal.js
@@ -387,6 +387,9 @@ export const createCell = function(i, j, value) {
     td.setAttribute('data-x', i);
     td.setAttribute('data-y', j);
 
+    if( obj.headers[i].style.display === 'none' ){
+        td.style.display = 'none';
+    }
     // Security
     if ((''+value).substr(0,1) == '=' && obj.options.secureFormulas == true) {
         const val = secureFormula(value);

--- a/src/utils/internal.js
+++ b/src/utils/internal.js
@@ -859,6 +859,10 @@ const updateFormulas = function(referencesToUpdate) {
  */
 export const updateTableReferences = function() {
     const obj = this;
+    if( obj.skipUpdateTableReferences ){
+        return;
+    }
+
 
     // Update headers
     for (let i = 0; i < obj.headers.length; i++) {

--- a/src/utils/selection.js
+++ b/src/utils/selection.js
@@ -575,7 +575,7 @@ export const copyData = function(o, d) {
 export const hash = function(str) {
     let hash = 0, i, chr;
 
-    if (str.length === 0) {
+    if (!str || str.length === 0) {
         return hash;
     } else {
         for (i = 0; i < str.length; i++) {

--- a/test/paste.cjs
+++ b/test/paste.cjs
@@ -1,30 +1,26 @@
 const { expect } = require("chai");
 
-function jspreadsheetFix(root, option) {
-  return jspreadsheet(root, {
-    worksheets: [
-      option
-    ],
-    ...option
-  })[0]
-}
+const fixtureData = () => [
+  ["Mazda", 2001, 2000, 1],
+  ["Peugeot", 2010, 5000, "=B2+C2"],
+  ["Honda Fit", 2009, 3000, "=B3+C3"],
+  ["Honda CRV", 2010, 6000, "=B4+C4"],
+];
+
 describe("Paste", () => {
   it("no expand", () => {
-    let test = jspreadsheetFix(root, {
-      data: [
-        ["Mazda", 2001, 2000, 1],
-        ["Peugeot", 2010, 5000, "=B2+C2"],
-        ["Honda Fit", 2009, 3000, "=B3+C3"],
-        ["Honda CRV", 2010, 6000, "=B4+C4"],
-      ],
-    });
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
 
     const pasteText =
       "0-0\t0-1\t0-2\t0-3\n1-0\t1-1\t1-2\t1-3\n2-0\t2-1\t2-2\t2-3\n3-0\t3-1\t3-2\t3-3";
-    test.updateSelectionFromCoords(0, 0, 0, 0);
-    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+    sheet.updateSelectionFromCoords(0, 0, 0, 0);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
 
-    expect(test.getData()).to.eql([
+    expect(sheet.getData()).to.eql([
       ["0-0", "0-1", "0-2", "0-3"],
       ["1-0", "1-1", "1-2", "1-3"],
       ["2-0", "2-1", "2-2", "2-3"],
@@ -33,21 +29,18 @@ describe("Paste", () => {
   });
 
   it("expand", () => {
-    let test = jspreadsheetFix(root, {
-      data: [
-        ["Mazda", 2001, 2000, 1],
-        ["Peugeot", 2010, 5000, "=B2+C2"],
-        ["Honda Fit", 2009, 3000, "=B3+C3"],
-        ["Honda CRV", 2010, 6000, "=B4+C4"],
-      ],
-    });
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
 
     const pasteText =
       "0-0\t0-1\t0-2\t0-3\n1-0\t1-1\t1-2\t1-3\n2-0\t2-1\t2-2\t2-3\n3-0\t3-1\t3-2\t3-3";
-    test.updateSelectionFromCoords(3, 3, 3, 3);
-    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+    sheet.updateSelectionFromCoords(3, 3, 3, 3);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
 
-    expect(test.getData()).to.eql([
+    expect(sheet.getData()).to.eql([
       ["Mazda", 2001, 2000, 1, "", "", ""],
       ["Peugeot", 2010, 5000, "=B2+C2", "", "", ""],
       ["Honda Fit", 2009, 3000, "=B3+C3", "", "", ""],
@@ -59,20 +52,17 @@ describe("Paste", () => {
   });
 
   it("repeat horizontal", () => {
-    let test = jspreadsheetFix(root, {
-      data: [
-        ["Mazda", 2001, 2000, 1],
-        ["Peugeot", 2010, 5000, "=B2+C2"],
-        ["Honda Fit", 2009, 3000, "=B3+C3"],
-        ["Honda CRV", 2010, 6000, "=B4+C4"],
-      ],
-    });
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
 
     const pasteText = "0-0\t0-1";
-    test.updateSelectionFromCoords(0, 0, 4, 0);
-    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+    sheet.updateSelectionFromCoords(0, 0, 4, 0);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
 
-    expect(test.getData()).to.eql([
+    expect(sheet.getData()).to.eql([
       ["0-0", "0-1", "0-0", "0-1"],
       ["Peugeot", 2010, 5000, "=B2+C2"],
       ["Honda Fit", 2009, 3000, "=B3+C3"],
@@ -81,20 +71,17 @@ describe("Paste", () => {
   });
 
   it("repeat vertical", () => {
-    let test = jspreadsheetFix(root, {
-      data: [
-        ["Mazda", 2001, 2000, 1],
-        ["Peugeot", 2010, 5000, "=B2+C2"],
-        ["Honda Fit", 2009, 3000, "=B3+C3"],
-        ["Honda CRV", 2010, 6000, "=B4+C4"],
-      ],
-    });
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
 
     const pasteText = "0-0\n1-0";
-    test.updateSelectionFromCoords(0, 0, 0, 4);
-    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+    sheet.updateSelectionFromCoords(0, 0, 0, 4);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
 
-    expect(test.getData()).to.eql([
+    expect(sheet.getData()).to.eql([
       ["0-0", 2001, 2000, 1],
       ["1-0", 2010, 5000, "=B2+C2"],
       ["0-0", 2009, 3000, "=B3+C3"],
@@ -103,20 +90,17 @@ describe("Paste", () => {
   });
 
   it("repeat rectangle", () => {
-    let test = jspreadsheetFix(root, {
-      data: [
-        ["Mazda", 2001, 2000, 1],
-        ["Peugeot", 2010, 5000, "=B2+C2"],
-        ["Honda Fit", 2009, 3000, "=B3+C3"],
-        ["Honda CRV", 2010, 6000, "=B4+C4"],
-      ],
-    });
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
 
     const pasteText = "0-0\t0-1\n1-0\t1-1";
-    test.updateSelectionFromCoords(1, 0, 1, 3);
-    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+    sheet.updateSelectionFromCoords(1, 0, 1, 3);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
 
-    expect(test.getData()).to.eql([
+    expect(sheet.getData()).to.eql([
       ["Mazda", "0-0", "0-1", 1],
       ["Peugeot", "1-0", "1-1", "=B2+C2"],
       ["Honda Fit", "0-0", "0-1", "=B3+C3"],
@@ -124,19 +108,62 @@ describe("Paste", () => {
     ]);
   });
 
+  it("skip hidden column", () => {
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        columns: [
+          { type: "text" },
+          { type: "text" },
+          { type: "hidden" }, // paste is skipped.
+          { type: "text" },
+        ],
+        data: fixtureData()
+      }],
+    })[0];
+
+    const pasteText = "0-0\t0-1\n1-0\t1-1";
+    sheet.updateSelectionFromCoords(1, 0, 1, 0);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
+
+    expect(sheet.getData()).to.eql([
+      ["Mazda", "0-0", 2000, "0-1"],
+      ["Peugeot", "1-0", 5000, "1-1"],
+      ["Honda Fit", 2009, 3000, "=B3+C3"],
+      ["Honda CRV", 2010, 6000, "=B4+C4"],
+    ]);
+  });
+
+  it("skip hidden row", () => {
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
+
+    const pasteText = "0-0\t0-1\n1-0\t1-1";
+    sheet.hideRow(1);
+    sheet.updateSelectionFromCoords(1, 0, 1, 0);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
+
+    expect(sheet.getData()).to.eql([
+      ["Mazda", "0-0", "0-1", 1],
+      ["Peugeot", 2010, 5000, "=B2+C2"],
+      ["Honda Fit", "1-0", "1-1", "=B3+C3"],
+      ["Honda CRV", 2010, 6000, "=B4+C4"],
+    ]);
+  });
+
+
   it("large data paste", () => {
     let count = {};
-    let test = jspreadsheetFix(root, {
-      data: [
-        ["Mazda", 2001, 2000, 1],
-        ["Peugeot", 2010, 5000, "=B2+C2"],
-        ["Honda Fit", 2009, 3000, "=B3+C3"],
-        ["Honda CRV", 2010, 6000, "=B4+C4"],
-      ],
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
       onevent: (event) => {
         count[event] = (count[event] ?? 0) + 1;
       },
-    });
+    })[0];
 
     const pasteText = new Array(1000)
       .fill(0)
@@ -147,14 +174,209 @@ describe("Paste", () => {
           .join("\t")
       )
       .join("\n");
-    test.updateSelectionFromCoords(3, 3, 3, 3);
-    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+    sheet.updateSelectionFromCoords(3, 3, 3, 3);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
     expect(count.onbeforechange).to.eql(20000);
-    expect(count.onbeforeinsertcolumn).to.eql(19);
-    expect(count.onbeforeinsertrow).to.eql(999);
+    expect(count.onbeforeinsertcolumn).to.eql(1);
+    expect(count.onbeforeinsertrow).to.eql(1);
     expect(count.onchange).to.eql(20000);
-    expect(count.oninsertcolumn).to.eql(19);
-    expect(count.oninsertrow).to.eql(999);
-    expect(count.onselection).to.eql(1020);
-  }).timeout(120 * 1000);
+    expect(count.oninsertcolumn).to.eql(1);
+    expect(count.oninsertrow).to.eql(1);
+    expect(count.onselection).to.eql(3);
+  }).timeout(10 * 1000);
+
+  it("expand with hidden cells", () => {
+    let count = {};
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        columns: [
+          { type: "text" },
+          { type: "text" },
+          { type: "hidden" }, // paste is skipped.
+          { type: "text" },
+        ],
+        data: fixtureData()
+      }],
+      onevent: (event) => {
+        count[event] = (count[event] ?? 0) + 1;
+      },
+    })[0];
+
+    const pasteText = "0-0\t0-1\t0-2\t0-3\n1-0\t1-1\t1-2\t1-3\n2-0\t2-1\t2-2\t2-3\n3-0\t3-1\t3-2\t3-3";;
+    sheet.hideRow(2);
+    sheet.updateSelectionFromCoords(1, 1, 1, 1);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
+    expect(sheet.getData()).to.eql([
+      ["Mazda", 2001, 2000, 1, "", ""],
+      ["Peugeot", "0-0", 5000, "0-1", "0-2", "0-3"],
+      ["Honda Fit", 2009, 3000, "=B3+C3", "", ""],
+      ["Honda CRV", "1-0", 6000, "1-1", "1-2", "1-3"],
+      ["", "2-0", "", "2-1", "2-2", "2-3"],
+      ["", "3-0", "", "3-1", "3-2", "3-3"],
+    ]);
+    expect(count.onbeforeinsertcolumn).to.eql(1);
+    expect(count.onbeforeinsertrow).to.eql(1);
+  }).timeout(10 * 1000);
+
+  it("copy and paste with style", () => {
+    global.document.execCommand = function execCommandMock() { };
+
+    let count = {};
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
+
+    sheet.setStyle("A1", "color", "red");
+    sheet.updateSelectionFromCoords(0, 0, 1, 1);
+    sheet.copy();
+    sheet.paste(2, 2, sheet.data);
+    expect(sheet.getData()).to.eql([
+      ["Mazda", 2001, 2000, 1],
+      ["Peugeot", 2010, 5000, "=B2+C2"],
+      ["Honda Fit", 2009, "Mazda", "2001"],
+      ["Honda CRV", 2010, "Peugeot", "2010"],
+    ]);
+    expect(sheet.getStyle("A1", "color")).to.eql("red");
+    expect(sheet.getStyle("C3", "color")).to.eql("red");
+  });
+
+  it("copy and repeat paste with style", () => {
+    global.document.execCommand = function execCommandMock() { };
+
+    let count = {};
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
+
+    sheet.setStyle("A1", "color", "red");
+    sheet.updateSelectionFromCoords(0, 0, 1, 0);
+    sheet.copy();
+    sheet.updateSelectionFromCoords(0, 2, 4, 4);
+    sheet.paste(0, 2, sheet.data);
+    expect(sheet.getData()).to.eql([
+      ["Mazda", 2001, 2000, 1],
+      ["Peugeot", 2010, 5000, "=B2+C2"],
+      ["Mazda", "2001", "Mazda", "2001"],
+      ["Mazda", "2001", "Mazda", "2001"],
+    ]);
+    //
+    expect(sheet.getStyle("A1", "color")).to.eql("red");
+    //
+    expect(sheet.getStyle("A3", "color")).to.eql("red");
+    expect(sheet.getStyle("B3", "color")).to.eql("");
+    expect(sheet.getStyle("C3", "color")).to.eql("red");
+    expect(sheet.getStyle("D3", "color")).to.eql("");
+    //
+    expect(sheet.getStyle("A4", "color")).to.eql("red");
+    expect(sheet.getStyle("B4", "color")).to.eql("");
+    expect(sheet.getStyle("C4", "color")).to.eql("red");
+    expect(sheet.getStyle("D4", "color")).to.eql("");
+  });
+
+  it("copy and paste to another sheet", async () => {
+    global.document.execCommand = function execCommandMock() { };
+
+    let isLoaded = false;
+    let sheets = jspreadsheet(root, {
+      tabs: true,
+      worksheets: [
+        {
+          data: fixtureData(),
+          worksheetName: "Sheet1",
+        },
+        {
+          data: fixtureData(),
+          worksheetName: "Sheet2",
+        }
+      ],
+      onload: (instance) => {
+        isLoaded = true;
+      }
+    });
+
+    const awaitLoop = (resolve) => {
+      setTimeout(() => {
+        if (isLoaded) {
+          resolve();
+        } else {
+          resolve(awaitLoop);
+        }
+      }, 100);
+    }
+    // NOTE: jpreadsheet constructor is acutally async. So it waits for load events in await.
+    await new Promise(awaitLoop);
+
+    const from = sheets[0];
+    from.setStyle("A1", "color", "red");
+    from.updateSelectionFromCoords(0, 0, 1, 0);
+    from.copy();
+    const to = sheets[1];
+    to.updateSelectionFromCoords(0, 2, 4, 4);
+    to.paste(0, 2, from.data);
+    expect(to.getData()).to.eql([
+      ["Mazda", 2001, 2000, 1],
+      ["Peugeot", 2010, 5000, "=B2+C2"],
+      ["Mazda", "2001", "Mazda", "2001"],
+      ["Mazda", "2001", "Mazda", "2001"],
+    ]);
+    // XXX: This is not working. It seems that the style is not copied.
+    // expect(to.getStyle("A1", "color")).to.eql("red");
+    // //
+    // expect(to.getStyle("A3", "color")).to.eql("red");
+    // expect(to.getStyle("B3", "color")).to.eql("");
+    // expect(to.getStyle("C3", "color")).to.eql("red");
+    // expect(to.getStyle("D3", "color")).to.eql("");
+    // //
+    // expect(to.getStyle("A4", "color")).to.eql("red");
+    // expect(to.getStyle("B4", "color")).to.eql("");
+    // expect(to.getStyle("C4", "color")).to.eql("red");
+    // expect(to.getStyle("D4", "color")).to.eql("");
+  })
+
+  it("fix - u0000 is pasted, when the last cell ends in a tab", () => {
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
+
+    const pasteText =
+      "0-0\t0-1\t0-2\t0-3\n1-0\t1-1\t1-2\t1-3\n2-0\t2-1\t2-2\t2-3\n3-0\t3-1\t3-2\t";
+    sheet.updateSelectionFromCoords(0, 0, 0, 0);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
+
+    expect(sheet.getData()).to.eql([
+      ["0-0", "0-1", "0-2", "0-3"],
+      ["1-0", "1-1", "1-2", "1-3"],
+      ["2-0", "2-1", "2-2", "2-3"],
+      ["3-0", "3-1", "3-2", ""],
+    ]);
+  });
+
+  it("paste lacked columns data", () => {
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        data: fixtureData()
+      }],
+    })[0];
+
+    const pasteText =
+      "0-0\t\n" +
+      "1-0\t1-1\t1-2\t1-3\n" +
+      "2-0\n" +
+      "3-0\t3-1\t3-2\t";
+    sheet.updateSelectionFromCoords(0, 0, 0, 0);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], pasteText);
+
+    expect(sheet.getData()).to.eql([
+      ["0-0", "", "", ""],
+      ["1-0", "1-1", "1-2", "1-3"],
+      ["2-0", "", "", ""],
+      ["3-0", "3-1", "3-2", ""],
+    ]);
+  });
 });

--- a/test/paste.cjs
+++ b/test/paste.cjs
@@ -1,5 +1,7 @@
 const { expect } = require("chai");
 
+global.document.execCommand = function execCommandMock() { };
+
 const fixtureData = () => [
   ["Mazda", 2001, 2000, 1],
   ["Peugeot", 2010, 5000, "=B2+C2"],
@@ -153,6 +155,31 @@ describe("Paste", () => {
     ]);
   });
 
+  it("see https://github.com/jspreadsheet/ce/pull/1717#issuecomment-2576060698", () => {
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        minDimensions: [4, 4],
+        data: [
+            [1, 2],
+            [3, 4],
+        ]
+      }],
+    })[0];
+
+    sheet.updateSelectionFromCoords(0, 0, 1, 1);
+    sheet.copy();
+    sheet.hideRow(0);
+    sheet.hideColumn(0);
+    sheet.updateSelectionFromCoords(2, 2, 2, 2);
+    sheet.paste(sheet.selectedCell[0], sheet.selectedCell[1], sheet.data);
+
+    expect(sheet.getData()).to.eql([
+      [1, 2, "", ""],
+      [3, 4, "", ""],
+      ["", "", "1", "2"],
+      ["", "", "3", "4"],
+]);
+  });
 
   it("large data paste", () => {
     let count = {};
@@ -219,8 +246,6 @@ describe("Paste", () => {
   }).timeout(10 * 1000);
 
   it("copy and paste with style", () => {
-    global.document.execCommand = function execCommandMock() { };
-
     let count = {};
     let sheet = jspreadsheet(root, {
       worksheets: [{

--- a/test/paste.cjs
+++ b/test/paste.cjs
@@ -160,8 +160,8 @@ describe("Paste", () => {
       worksheets: [{
         minDimensions: [4, 4],
         data: [
-            [1, 2],
-            [3, 4],
+          [1, 2],
+          [3, 4],
         ]
       }],
     })[0];
@@ -178,7 +178,42 @@ describe("Paste", () => {
       [3, 4, "", ""],
       ["", "", "1", "2"],
       ["", "", "3", "4"],
-]);
+    ]);
+  });
+
+  it("see https://github.com/jspreadsheet/ce/pull/1717#issuecomment-2580087207", () => {
+    let sheet = jspreadsheet(root, {
+      worksheets: [{
+        minDimensions: [10, 4],
+        data: [
+          [1, 2, 3],
+          [4, 5, 6],
+        ]
+      }],
+    })[0];
+
+    sheet.updateSelectionFromCoords(0, 0, 2, 1);
+    sheet.copy();
+    sheet.hideColumn(8);
+    sheet.hideColumn(9);
+    sheet.hideRow(3);
+    sheet.updateSelectionFromCoords(7, 2, 7, 2);
+    expect(sheet.getData()).to.eql([
+      [1, 2, 3, "", "", "", "", "", "", ""],
+      [4, 5, 6, "", "", "", "", "", "", ""],
+      ["", "", "", "", "", "", "", "", "", ""],
+      ["", "", "", "", "", "", "", "", "", ""],
+    ]);
+
+    sheet.paste(7, 2, sheet.data);
+
+    expect(sheet.getData()).to.eql([
+      [1,  2,  3,  "", "", "", "", "", "", "", "", ""],
+      [4,  5,  6,  "", "", "", "", "", "", "", "", ""],
+      ["", "", "", "", "", "", "", "1", "", "", "2", "3"],
+      ["", "", "", "", "", "", "", "", "", "", "", ""],
+      ["", "", "", "", "", "", "", "4", "", "", "5", "6"],
+    ]);
   });
 
   it("large data paste", () => {

--- a/test/paste.cjs
+++ b/test/paste.cjs
@@ -1,0 +1,160 @@
+const { expect } = require("chai");
+
+function jspreadsheetFix(root, option) {
+  return jspreadsheet(root, {
+    worksheets: [
+      option
+    ],
+    ...option
+  })[0]
+}
+describe("Paste", () => {
+  it("no expand", () => {
+    let test = jspreadsheetFix(root, {
+      data: [
+        ["Mazda", 2001, 2000, 1],
+        ["Peugeot", 2010, 5000, "=B2+C2"],
+        ["Honda Fit", 2009, 3000, "=B3+C3"],
+        ["Honda CRV", 2010, 6000, "=B4+C4"],
+      ],
+    });
+
+    const pasteText =
+      "0-0\t0-1\t0-2\t0-3\n1-0\t1-1\t1-2\t1-3\n2-0\t2-1\t2-2\t2-3\n3-0\t3-1\t3-2\t3-3";
+    test.updateSelectionFromCoords(0, 0, 0, 0);
+    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+
+    expect(test.getData()).to.eql([
+      ["0-0", "0-1", "0-2", "0-3"],
+      ["1-0", "1-1", "1-2", "1-3"],
+      ["2-0", "2-1", "2-2", "2-3"],
+      ["3-0", "3-1", "3-2", "3-3"],
+    ]);
+  });
+
+  it("expand", () => {
+    let test = jspreadsheetFix(root, {
+      data: [
+        ["Mazda", 2001, 2000, 1],
+        ["Peugeot", 2010, 5000, "=B2+C2"],
+        ["Honda Fit", 2009, 3000, "=B3+C3"],
+        ["Honda CRV", 2010, 6000, "=B4+C4"],
+      ],
+    });
+
+    const pasteText =
+      "0-0\t0-1\t0-2\t0-3\n1-0\t1-1\t1-2\t1-3\n2-0\t2-1\t2-2\t2-3\n3-0\t3-1\t3-2\t3-3";
+    test.updateSelectionFromCoords(3, 3, 3, 3);
+    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+
+    expect(test.getData()).to.eql([
+      ["Mazda", 2001, 2000, 1, "", "", ""],
+      ["Peugeot", 2010, 5000, "=B2+C2", "", "", ""],
+      ["Honda Fit", 2009, 3000, "=B3+C3", "", "", ""],
+      ["Honda CRV", 2010, 6000, "0-0", "0-1", "0-2", "0-3"],
+      ["", "", "", "1-0", "1-1", "1-2", "1-3"],
+      ["", "", "", "2-0", "2-1", "2-2", "2-3"],
+      ["", "", "", "3-0", "3-1", "3-2", "3-3"],
+    ]);
+  });
+
+  it("repeat horizontal", () => {
+    let test = jspreadsheetFix(root, {
+      data: [
+        ["Mazda", 2001, 2000, 1],
+        ["Peugeot", 2010, 5000, "=B2+C2"],
+        ["Honda Fit", 2009, 3000, "=B3+C3"],
+        ["Honda CRV", 2010, 6000, "=B4+C4"],
+      ],
+    });
+
+    const pasteText = "0-0\t0-1";
+    test.updateSelectionFromCoords(0, 0, 4, 0);
+    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+
+    expect(test.getData()).to.eql([
+      ["0-0", "0-1", "0-0", "0-1"],
+      ["Peugeot", 2010, 5000, "=B2+C2"],
+      ["Honda Fit", 2009, 3000, "=B3+C3"],
+      ["Honda CRV", 2010, 6000, "=B4+C4"],
+    ]);
+  });
+
+  it("repeat vertical", () => {
+    let test = jspreadsheetFix(root, {
+      data: [
+        ["Mazda", 2001, 2000, 1],
+        ["Peugeot", 2010, 5000, "=B2+C2"],
+        ["Honda Fit", 2009, 3000, "=B3+C3"],
+        ["Honda CRV", 2010, 6000, "=B4+C4"],
+      ],
+    });
+
+    const pasteText = "0-0\n1-0";
+    test.updateSelectionFromCoords(0, 0, 0, 4);
+    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+
+    expect(test.getData()).to.eql([
+      ["0-0", 2001, 2000, 1],
+      ["1-0", 2010, 5000, "=B2+C2"],
+      ["0-0", 2009, 3000, "=B3+C3"],
+      ["1-0", 2010, 6000, "=B4+C4"],
+    ]);
+  });
+
+  it("repeat rectangle", () => {
+    let test = jspreadsheetFix(root, {
+      data: [
+        ["Mazda", 2001, 2000, 1],
+        ["Peugeot", 2010, 5000, "=B2+C2"],
+        ["Honda Fit", 2009, 3000, "=B3+C3"],
+        ["Honda CRV", 2010, 6000, "=B4+C4"],
+      ],
+    });
+
+    const pasteText = "0-0\t0-1\n1-0\t1-1";
+    test.updateSelectionFromCoords(1, 0, 1, 3);
+    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+
+    expect(test.getData()).to.eql([
+      ["Mazda", "0-0", "0-1", 1],
+      ["Peugeot", "1-0", "1-1", "=B2+C2"],
+      ["Honda Fit", "0-0", "0-1", "=B3+C3"],
+      ["Honda CRV", "1-0", "1-1", "=B4+C4"],
+    ]);
+  });
+
+  it("large data paste", () => {
+    let count = {};
+    let test = jspreadsheetFix(root, {
+      data: [
+        ["Mazda", 2001, 2000, 1],
+        ["Peugeot", 2010, 5000, "=B2+C2"],
+        ["Honda Fit", 2009, 3000, "=B3+C3"],
+        ["Honda CRV", 2010, 6000, "=B4+C4"],
+      ],
+      onevent: (event) => {
+        count[event] = (count[event] ?? 0) + 1;
+      },
+    });
+
+    const pasteText = new Array(1000)
+      .fill(0)
+      .map((v, i) =>
+        new Array(20)
+          .fill(0)
+          .map((v2, i2) => `${i}-${i2}`)
+          .join("\t")
+      )
+      .join("\n");
+    test.updateSelectionFromCoords(3, 3, 3, 3);
+    test.paste(test.selectedCell[0], test.selectedCell[1], pasteText);
+    expect(count.onbeforechange).to.eql(20000);
+    expect(count.onbeforeinsertcolumn).to.eql(19);
+    expect(count.onbeforeinsertrow).to.eql(999);
+    expect(count.onchange).to.eql(20000);
+    expect(count.oninsertcolumn).to.eql(19);
+    expect(count.oninsertrow).to.eql(999);
+    expect(count.onselection).to.eql(1020);
+  }).timeout(120 * 1000);
+});


### PR DESCRIPTION
See #1705 for an abstract.

> It appears that the #1681 pr is being rolled back in v5.

reapplied #1681 and improved style copy.

> When the last cell ends in a tab, “\0” is pasted.
> When paste lacked columns data, target cells is retained.

fix parseCSV.