### PR TITLE
Fix WorksheetInstance.records type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2099,7 +2099,7 @@ declare namespace jspreadsheet {
      * List of HTML elements representing table cells.
      */
     records: {
-      element: HTMLTableCellElement[][],
+      element: HTMLTableCellElement,
       x: number,
       y: number,
     }[][];


### PR DESCRIPTION
I noticed the type in `index.d.ts` for `WorksheetInstance.records` is not correct.
`WorksheetInstance.records` is itself a 2-dimensional array, but each record holds a single `HTMLTableCellElement` alongside its x and y coordinates.